### PR TITLE
Add time range filtering for backload functionality

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,17 +50,19 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64
+        # Multi-platform only on main/tags, single platform for PRs (faster)
+        platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache
-        cache-to: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache,mode=max
+        # Only use registry cache on main/tags (avoids auth issues on PRs)
+        cache-from: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache', env.DOCKERHUB_REPO) || 'type=gha' }}
+        cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache,mode=max', env.DOCKERHUB_REPO) || 'type=gha,mode=max' }}
 
     - name: Image digest
       run: echo "Image published with digest ${{ steps.build.outputs.digest }}"
 
-    - name: Summary
+    - name: Summary - Published
       if: github.event_name != 'pull_request'
       run: |
         echo "## Docker Image Published! 🚀" >> $GITHUB_STEP_SUMMARY
@@ -78,3 +80,16 @@ jobs:
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**View on DockerHub:** https://hub.docker.com/r/${{ env.DOCKERHUB_REPO }}" >> $GITHUB_STEP_SUMMARY
+
+    - name: Summary - PR Build Only
+      if: github.event_name == 'pull_request'
+      run: |
+        echo "## Docker Build Validated ✅" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Docker image built successfully for PR validation." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Note:** Image was not pushed to DockerHub (PR builds are for validation only)." >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Once merged to main, the image will be published to:" >> $GITHUB_STEP_SUMMARY
+        echo "- \`${{ env.DOCKERHUB_REPO }}:latest\`" >> $GITHUB_STEP_SUMMARY
+        echo "- Version-specific tag from \`pyproject.toml\`" >> $GITHUB_STEP_SUMMARY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "1.0.1"
+version = "1.1.0"
 description = "Weather radar data processor for DWD and SHMU weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -283,9 +283,20 @@ def fetch_command(args) -> int:
 
             # Download data (don't use LATEST for backload)
             if args.source == 'dwd':
-                files = source.download_latest(count=intervals, products=[product], use_latest=False)
+                files = source.download_latest(
+                    count=intervals,
+                    products=[product],
+                    use_latest=False,
+                    start_time=start,
+                    end_time=end
+                )
             else:  # SHMU
-                files = source.download_latest(count=intervals, products=[product])
+                files = source.download_latest(
+                    count=intervals,
+                    products=[product],
+                    start_time=start,
+                    end_time=end
+                )
 
             if not files:
                 print("❌ No data available for the specified period")


### PR DESCRIPTION
## Summary
- Implement precise time range filtering for backload operations in both DWD and SHMU radar sources
- Add `start_time` and `end_time` parameters to `download_latest()` methods
- Enable users to download data for specific time periods instead of counting backwards from current time

## Changes
- **CLI** (`cli.py`): Pass time range parameters to source `download_latest()` calls during backload
- **DWD Source** (`dwd.py`): Add `_filter_timestamps_by_range()` method with UTC timezone-aware filtering
- **SHMU Source** (`shmu.py`): Add `_filter_timestamps_by_range()` method with UTC timezone-aware filtering

## Technical Details
- Uses `pytz.UTC` for timezone-aware datetime comparisons
- Filters timestamps after fetching from server directory listings
- DWD format: `YYYYMMDD_HHMM`, SHMU format: `YYYYMMDDHHMM00`
- Generates more candidate timestamps when filtering is enabled (8x multiplier for SHMU)

## Benefits
- Fill specific gaps in historical data
- Re-download data for targeted time periods  
- Avoid unnecessary downloads outside desired time windows
- More efficient bandwidth usage during backload operations

## Test Plan
- [ ] Test DWD backload with time range: `imeteo-radar fetch --source dwd --backload --from "2024-09-25 10:00" --to "2024-09-25 16:00"`
- [ ] Test SHMU backload with time range: `imeteo-radar fetch --source shmu --backload --from "2024-09-25 10:00" --to "2024-09-25 16:00"`
- [ ] Verify filtered timestamps match the specified range
- [ ] Confirm existing backload without time range still works (backwards compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)