### PR TITLE
feat: Add individual source image export during composite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Individual source image export during composite generation
+  - Each source (DWD, SHMU, CHMI) now exports to its native grid alongside the composite
+  - Output directories: `/tmp/germany/`, `/tmp/slovakia/`, `/tmp/czechia/`
+  - Same timestamp-based filenames as composite (`{unix_timestamp}.png`)
+- `--no-individual` CLI flag for composite command to skip individual source images
+
 ## [1.0.0] - 2025-09-25
 
 ### Added

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -138,6 +138,11 @@ def create_parser() -> argparse.ArgumentParser:
         action='store_true',
         help='Force update extent_index.json file'
     )
+    composite_parser.add_argument(
+        '--no-individual',
+        action='store_true',
+        help='Skip generating individual source images (only create composite)'
+    )
 
     return parser
 


### PR DESCRIPTION
## Summary
- When running `imeteo-radar composite`, individual source images are now exported alongside the composite
- Each source (DWD, SHMU, CHMI) exports to its native grid with proper extent
- Added `--no-individual` flag to skip individual images if only composite is needed

## Changes
- Modified `cli_composite.py` to export individual source images before creating composite
- Added `_export_individual_sources()` helper function
- Added `--no-individual` CLI flag in `cli.py`
- Updated `CHANGELOG.md`

## Output Structure
```
/tmp/germany/{timestamp}.png      # DWD native grid
/tmp/slovakia/{timestamp}.png     # SHMU native grid  
/tmp/czechia/{timestamp}.png      # CHMI native grid
/tmp/composite/{timestamp}.png    # Merged composite grid
```

## Test plan
- [x] Tested `imeteo-radar composite --sources dwd,shmu,chmi` - generates 4 images
- [x] Tested `imeteo-radar composite --no-individual` - generates only composite

🤖 Generated with [Claude Code](https://claude.com/claude-code)