### PR TITLE
feat: Add ARSO Slovenia radar source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-01-09
+
+### Added
+- ARSO (Slovenian Environment Agency) radar source support
+  - `zm` product (maximum reflectivity)
+  - `rrg` product (ground rain rate)
+  - Coverage: Slovenia (12.1°-17.4°E, 44.7°-47.4°N)
+  - Uses proprietary SRD-3 format with custom parser
+  - Lambert Conformal Conic projection support via pyproj
+- CLI support: `imeteo-radar fetch --source arso`
+
 ## [1.2.2] - 2026-01-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "1.2.2"
-description = "Weather radar data processor for DWD, SHMU, and CHMI weather radar data"
+version = "1.3.0"
+description = "Weather radar data processor for DWD, SHMU, CHMI, and ARSO weather radar data"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -29,9 +29,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     fetch_parser.add_argument(
         '--source',
-        choices=['dwd', 'shmu', 'chmi'],
+        choices=['dwd', 'shmu', 'chmi', 'arso'],
         default='dwd',
-        help='Radar source (DWD for Germany, SHMU for Slovakia, CHMI for Czechia)'
+        help='Radar source (DWD for Germany, SHMU for Slovakia, CHMI for Czechia, ARSO for Slovenia)'
     )
     fetch_parser.add_argument(
         '--output',
@@ -78,7 +78,7 @@ def create_parser() -> argparse.ArgumentParser:
     )
     extent_parser.add_argument(
         '--source',
-        choices=['dwd', 'shmu', 'chmi', 'all'],
+        choices=['dwd', 'shmu', 'chmi', 'arso', 'all'],
         default='all',
         help='Radar source(s) to generate extent for'
     )
@@ -269,6 +269,7 @@ def fetch_command(args) -> int:
         from .sources.dwd import DWDRadarSource
         from .sources.shmu import SHMURadarSource
         from .sources.chmi import CHMIRadarSource
+        from .sources.arso import ARSORadarSource
         from .processing.exporter import PNGExporter
         from .utils.spaces_uploader import SpacesUploader, is_spaces_configured
 
@@ -285,6 +286,10 @@ def fetch_command(args) -> int:
             source = CHMIRadarSource()
             product = 'maxz'
             country_dir = 'czechia'
+        elif args.source == 'arso':
+            source = ARSORadarSource()
+            product = 'zm'
+            country_dir = 'slovenia'
         else:
             print(f"❌ Unknown source: {args.source}")
             return 1
@@ -530,6 +535,7 @@ def extent_command(args) -> int:
         from .sources.dwd import DWDRadarSource
         from .sources.shmu import SHMURadarSource
         from .sources.chmi import CHMIRadarSource
+        from .sources.arso import ARSORadarSource
         import json
 
         sources_to_process = []
@@ -542,6 +548,9 @@ def extent_command(args) -> int:
 
         if args.source == 'all' or args.source == 'chmi':
             sources_to_process.append(('chmi', CHMIRadarSource(), 'czechia'))
+
+        if args.source == 'all' or args.source == 'arso':
+            sources_to_process.append(('arso', ARSORadarSource(), 'slovenia'))
 
         combined_extent = {
             "metadata": {

--- a/src/imeteo_radar/sources/arso.py
+++ b/src/imeteo_radar/sources/arso.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""
+ARSO (Agencija Republike Slovenije za okolje) Radar Source
+
+Handles downloading and processing of ARSO radar data in SRD-3 format.
+SRD-3 is a proprietary Slovenian Radar Data format with ASCII header
+and byte-encoded data using Lambert Conformal Conic projection.
+
+Documentation: https://meteo.arso.gov.si/uploads/meteo/help/sl/SRD3Format.html
+"""
+
+import os
+import numpy as np
+import requests
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+from pyproj import CRS, Transformer
+
+from ..core.base import RadarSource, lonlat_to_mercator
+
+
+class ARSORadarSource(RadarSource):
+    """ARSO Slovenia radar data source using SRD-3 format"""
+
+    BASE_URL = "https://meteo.arso.gov.si/uploads/probase/www/observ/radar"
+
+    # Product mapping: internal name -> (filename, description)
+    PRODUCTS = {
+        'zm': {
+            'file': 'si0-zm.srd',
+            'name': 'Maximum Reflectivity (ZM)',
+            'units': 'dBZ',
+            'description': 'Column maximum reflectivity'
+        },
+        'rrg': {
+            'file': 'si0-rrg.srd',
+            'name': 'Ground Rain Rate (RRG)',
+            'units': 'dBR/h',
+            'description': 'Precipitation intensity at ground level'
+        }
+    }
+
+    # SIRAD projection parameters (from SRD-3 specification)
+    # Lambert Conformal Conic centered on GEOSS reference point
+    SIRAD_PROJ4 = (
+        "+proj=lcc +lat_1=46.12 +lat_2=46.12 +lat_0=46.12 "
+        "+lon_0=14.815 +x_0=0 +y_0=0 +R=6371000 +units=km +no_defs"
+    )
+
+    # Grid parameters (from SRD-3 specification)
+    # Domain: 400x300 km, cells: 401x301, cellsize: 1km
+    # Center offset: 4 km west, 6 km south of GEOSS (14.815, 46.12)
+    GRID_NCELL = (401, 301)  # (width, height) = (i, j) = (zonal, meridional)
+    GRID_CELLSIZE = 1.0  # km
+    GRID_CENTER = (201, 151)  # Grid center cell indices
+    GEOSS_CELL = (205, 145)  # GEOSS reference point cell indices
+
+    def __init__(self):
+        super().__init__("arso")
+
+        # Track temporary files for cleanup
+        self.temp_files = {}
+
+        # Initialize projection transformer
+        self.sirad_crs = CRS.from_proj4(self.SIRAD_PROJ4)
+        self.wgs84_crs = CRS.from_epsg(4326)
+        self.transformer = Transformer.from_crs(
+            self.sirad_crs, self.wgs84_crs, always_xy=True
+        )
+
+        # Pre-compute grid coordinates (only done once)
+        self._lons = None
+        self._lats = None
+        self._extent_wgs84 = None
+
+    def get_available_products(self) -> List[str]:
+        """Get list of available ARSO radar products"""
+        return list(self.PRODUCTS.keys())
+
+    def get_product_metadata(self, product: str) -> Dict[str, Any]:
+        """Get metadata for a specific ARSO product"""
+        if product in self.PRODUCTS:
+            return {
+                'product': product,
+                'source': self.name,
+                **self.PRODUCTS[product]
+            }
+        return super().get_product_metadata(product)
+
+    def _get_product_url(self, product: str) -> str:
+        """Generate URL for ARSO product"""
+        if product not in self.PRODUCTS:
+            raise ValueError(f"Unknown product: {product}")
+
+        filename = self.PRODUCTS[product]['file']
+        return f"{self.BASE_URL}/{filename}"
+
+    def _parse_srd_header(self, content: str) -> Dict[str, Any]:
+        """Parse SRD-3 format header
+
+        Header format: "key value1 value2 ... # optional comment"
+        """
+        header = {}
+        lines = content.split('\n')
+
+        for line in lines:
+            # Stop at DATA marker
+            if line.strip() == 'DATA':
+                break
+
+            # Remove comments and strip whitespace
+            line = line.split('#')[0].strip()
+            if not line:
+                continue
+
+            # Parse key-value pairs
+            parts = line.split()
+            if len(parts) >= 2:
+                key = parts[0]
+                values = parts[1:]
+                # Convert to appropriate types
+                if len(values) == 1:
+                    # Single value - try to convert to number
+                    try:
+                        header[key] = int(values[0])
+                    except ValueError:
+                        try:
+                            header[key] = float(values[0])
+                        except ValueError:
+                            header[key] = values[0]
+                else:
+                    # Multiple values - try to convert each
+                    converted = []
+                    for v in values:
+                        try:
+                            converted.append(int(v))
+                        except ValueError:
+                            try:
+                                converted.append(float(v))
+                            except ValueError:
+                                converted.append(v)
+                    header[key] = converted
+            elif len(parts) == 1:
+                header[parts[0]] = None
+
+        return header
+
+    def _parse_srd_data(self, content: str, header: Dict[str, Any]) -> np.ndarray:
+        """Parse SRD-3 data section
+
+        Data is byte-encoded as ASCII characters starting from offset (default 64='@').
+        Values are calculated as: value = start + slope * (byte_value - offset)
+        """
+        # Find DATA marker
+        data_start = content.find('\nDATA\n')
+        if data_start == -1:
+            data_start = content.find('\nDATA\r\n')
+        if data_start == -1:
+            raise ValueError("No DATA marker found in SRD file")
+
+        # Extract data section (everything after DATA\n)
+        data_section = content[data_start + 6:]  # Skip "\nDATA\n"
+
+        # Get grid dimensions from header
+        ncell = header.get('ncell', self.GRID_NCELL)
+        if isinstance(ncell, list):
+            width, height = ncell[0], ncell[1]
+        else:
+            width, height = self.GRID_NCELL
+
+        # Get quantization parameters
+        offset = header.get('offset', 64)
+        start = header.get('start', 12.0)
+        slope = header.get('slope', 3.0)
+
+        # Parse data - each character represents one byte value
+        # Data is organized: k (vertical), j (meridional, N-S), i (zonal, W-E)
+        # For 2D fields, rows are j (north to south), columns are i (west to east)
+        raw_data = []
+        for char in data_section:
+            byte_val = ord(char)
+            # Skip newlines and control characters
+            if byte_val < 32:
+                continue
+            raw_data.append(byte_val)
+
+        # Convert to numpy array
+        raw_array = np.array(raw_data, dtype=np.int32)
+
+        # Check if we have enough data
+        expected_size = width * height
+        if len(raw_array) < expected_size:
+            print(f"Warning: Expected {expected_size} values, got {len(raw_array)}")
+            # Pad with nodata
+            raw_array = np.pad(raw_array, (0, expected_size - len(raw_array)),
+                              constant_values=offset)
+        elif len(raw_array) > expected_size:
+            raw_array = raw_array[:expected_size]
+
+        # Reshape to 2D (height x width) - data is stored row by row (j=N-S, i=W-E)
+        raw_array = raw_array.reshape((height, width))
+
+        # Apply quantization formula: value = start + slope * (byte - offset)
+        scaled_data = start + slope * (raw_array.astype(np.float32) - offset)
+
+        # Values at offset (typically '@' = 64) represent no data / below threshold
+        scaled_data[raw_array == offset] = np.nan
+
+        return scaled_data
+
+    def _compute_grid_coordinates(self):
+        """Compute WGS84 coordinates for each grid cell (cached)"""
+        if self._lons is not None:
+            return
+
+        width, height = self.GRID_NCELL
+
+        # Grid cell indices
+        # i = 1 to 401 (zonal/W-E), j = 1 to 301 (meridional/N-S)
+        # Grid center at [201, 151], GEOSS at [205, 145]
+        # GEOSS offset: 4 km west, 6 km south from center
+
+        # Calculate x,y coordinates in km from GEOSS reference
+        # Center cell offset from GEOSS: (201-205, 151-145) = (-4, 6) cells = (-4, 6) km
+        # So GEOSS is at (0, 0) in projection coordinates
+
+        # Create grid of cell indices (1-indexed as per spec)
+        i_indices = np.arange(1, width + 1)
+        j_indices = np.arange(1, height + 1)
+
+        # Convert cell indices to km coordinates
+        # x = (i - GEOSS_i) * cellsize, y = (GEOSS_j - j) * cellsize
+        # Note: j increases southward in data, but y increases northward in projection
+        geoss_i, geoss_j = self.GEOSS_CELL
+        x_km = (i_indices - geoss_i) * self.GRID_CELLSIZE
+        y_km = (geoss_j - j_indices) * self.GRID_CELLSIZE
+
+        # Create 2D meshgrid
+        x_grid, y_grid = np.meshgrid(x_km, y_km)
+
+        # Transform to WGS84
+        lons, lats = self.transformer.transform(x_grid, y_grid)
+
+        self._lons = lons
+        self._lats = lats
+
+        # Calculate extent
+        self._extent_wgs84 = {
+            'west': float(np.min(lons)),
+            'east': float(np.max(lons)),
+            'south': float(np.min(lats)),
+            'north': float(np.max(lats))
+        }
+
+    def _download_single_file(self, product: str) -> Dict[str, Any]:
+        """Download a single radar file"""
+        if product not in self.PRODUCTS:
+            return {
+                'error': f"Unknown product: {product}",
+                'product': product,
+                'success': False
+            }
+
+        try:
+            url = self._get_product_url(product)
+
+            # Check if we've already downloaded this file in this session
+            cache_key = f"latest_{product}"
+            if cache_key in self.temp_files:
+                # Check if file still exists
+                if os.path.exists(self.temp_files[cache_key]):
+                    return {
+                        'product': product,
+                        'path': self.temp_files[cache_key],
+                        'url': url,
+                        'cached': True,
+                        'success': True
+                    }
+
+            # Download to temporary file
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+
+            # Save to temp file
+            with tempfile.NamedTemporaryFile(
+                suffix=f'_arso_{product}.srd',
+                delete=False,
+                mode='wb'
+            ) as temp_file:
+                temp_file.write(response.content)
+                temp_path = Path(temp_file.name)
+
+            # Track the temporary file
+            self.temp_files[cache_key] = str(temp_path)
+
+            return {
+                'product': product,
+                'path': str(temp_path),
+                'url': url,
+                'cached': False,
+                'success': True
+            }
+
+        except Exception as e:
+            return {
+                'error': str(e),
+                'product': product,
+                'success': False
+            }
+
+    def download_latest(self, count: int = 1, products: List[str] = None,
+                       start_time: Optional[datetime] = None,
+                       end_time: Optional[datetime] = None) -> List[Dict[str, Any]]:
+        """Download latest ARSO radar data
+
+        Note: ARSO only provides the latest data at fixed URLs (no archive).
+        The count, start_time, and end_time parameters are accepted for
+        interface compatibility but are effectively ignored.
+
+        Args:
+            count: Not used (ARSO only provides latest data)
+            products: List of products to download (default: ['zm'])
+            start_time: Not used
+            end_time: Not used
+
+        Returns:
+            List of downloaded file information dictionaries
+        """
+        if products is None:
+            products = ['zm']  # Default to max reflectivity
+
+        print(f"📡 Downloading ARSO radar data ({', '.join(products)})...")
+
+        # Note: ARSO doesn't provide historical data via public URL
+        if count > 1 or start_time or end_time:
+            print("⚠️  ARSO only provides latest data (no archive access)")
+
+        downloaded_files = []
+
+        for product in products:
+            result = self._download_single_file(product)
+            if result['success']:
+                # Get timestamp from header by reading file
+                try:
+                    with open(result['path'], 'r', encoding='latin-1') as f:
+                        content = f.read()
+                    header = self._parse_srd_header(content)
+                    time_parts = header.get('time', [])
+                    if isinstance(time_parts, list) and len(time_parts) >= 5:
+                        timestamp = f"{time_parts[0]:04d}{time_parts[1]:02d}{time_parts[2]:02d}{time_parts[3]:02d}{time_parts[4]:02d}00"
+                    else:
+                        # Fallback to current time
+                        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M00")
+                    result['timestamp'] = timestamp
+                except Exception as e:
+                    print(f"⚠️  Could not parse timestamp: {e}")
+                    result['timestamp'] = datetime.utcnow().strftime("%Y%m%d%H%M00")
+
+                downloaded_files.append(result)
+                if result['cached']:
+                    print(f"📁 Using cached: {product}")
+                else:
+                    print(f"✅ Downloaded: {product} (timestamp: {result['timestamp']})")
+            else:
+                print(f"❌ Failed {product}: {result.get('error', 'Unknown error')}")
+
+        print(f"📋 ARSO: Downloaded {len(downloaded_files)} files")
+        return downloaded_files
+
+    def process_to_array(self, file_path: str) -> Dict[str, Any]:
+        """Process ARSO SRD file to array with metadata"""
+
+        try:
+            # Read file content
+            with open(file_path, 'r', encoding='latin-1') as f:
+                content = f.read()
+
+            # Parse header and data
+            header = self._parse_srd_header(content)
+            data = self._parse_srd_data(content, header)
+
+            # Ensure grid coordinates are computed
+            self._compute_grid_coordinates()
+
+            # Extract timestamp from header
+            time_parts = header.get('time', [])
+            if isinstance(time_parts, list) and len(time_parts) >= 5:
+                timestamp = f"{time_parts[0]:04d}{time_parts[1]:02d}{time_parts[2]:02d}{time_parts[3]:02d}{time_parts[4]:02d}00"
+            else:
+                timestamp = datetime.utcnow().strftime("%Y%m%d%H%M00")
+
+            # Determine product type from filename or header
+            domain = header.get('domain', 'SI0')
+            unit = header.get('unit', 'DBZ')
+            product = 'ZM' if 'zm' in file_path.lower() else 'RRG'
+            quantity = 'DBZH' if unit == 'DBZ' else 'RATE'
+
+            return {
+                'data': data,
+                'coordinates': {
+                    'lons': self._lons,
+                    'lats': self._lats
+                },
+                'metadata': {
+                    'product': product,
+                    'quantity': quantity,
+                    'timestamp': timestamp,
+                    'source': 'ARSO',
+                    'units': self._get_units(unit),
+                    'nodata_value': np.nan,
+                    'domain': domain,
+                    'projection': 'LCC (SIRAD)'
+                },
+                'extent': {
+                    'wgs84': self._extent_wgs84
+                },
+                'dimensions': data.shape,
+                'timestamp': timestamp[:14]  # YYYYMMDDHHMMSS format
+            }
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to process ARSO file {file_path}: {e}")
+
+    def _get_units(self, unit: str) -> str:
+        """Get human-readable units"""
+        units_map = {
+            'DBZ': 'dBZ',
+            'DBRH': 'dBR/h',
+            'MM': 'mm'
+        }
+        return units_map.get(unit.upper(), unit)
+
+    def get_extent(self) -> Dict[str, Any]:
+        """Get ARSO radar coverage extent"""
+
+        # Ensure coordinates are computed
+        self._compute_grid_coordinates()
+
+        # Convert to Web Mercator
+        x_min, y_min = lonlat_to_mercator(
+            self._extent_wgs84['west'],
+            self._extent_wgs84['south']
+        )
+        x_max, y_max = lonlat_to_mercator(
+            self._extent_wgs84['east'],
+            self._extent_wgs84['north']
+        )
+
+        return {
+            'wgs84': self._extent_wgs84,
+            'mercator': {
+                'x_min': x_min,
+                'x_max': x_max,
+                'y_min': y_min,
+                'y_max': y_max,
+                'bounds': [x_min, y_min, x_max, y_max]
+            },
+            'projection': 'EPSG:3857',
+            'grid_size': [self.GRID_NCELL[1], self.GRID_NCELL[0]],  # [height, width]
+            'resolution_m': [1000, 1000]  # 1 km resolution
+        }
+
+    def cleanup_temp_files(self):
+        """Clean up all temporary files created during this session"""
+        cleaned_count = 0
+        for cache_key, file_path in list(self.temp_files.items()):
+            try:
+                if os.path.exists(file_path):
+                    os.unlink(file_path)
+                    cleaned_count += 1
+                del self.temp_files[cache_key]
+            except Exception as e:
+                print(f"⚠️  Could not delete temp file {file_path}: {e}")
+
+        if cleaned_count > 0:
+            print(f"🧹 Cleaned up {cleaned_count} temporary ARSO files")
+        return cleaned_count


### PR DESCRIPTION
## Summary
- Add ARSO (Slovenian Environment Agency) radar source
- Implement SRD-3 format parser (proprietary Slovenian radar format)
- Support Lambert Conformal Conic projection conversion via pyproj
- Coverage: Slovenia (12.1°-17.4°E, 44.7°-47.4°N)
- Grid: 401×301 at 1km resolution
- Products: `zm` (max reflectivity), `rrg` (rain rate)

## Changes
- New file: `src/imeteo_radar/sources/arso.py` - ARSO source with SRD-3 parser
- Modified: `src/imeteo_radar/cli.py` - Added ARSO to fetch and extent commands
- Updated: `pyproject.toml` - Version bump 1.2.2 → 1.3.0
- Updated: `CHANGELOG.md` - Added v1.3.0 release notes

## Test plan
- [x] Download ARSO radar data: `imeteo-radar fetch --source arso --disable-upload`
- [x] Verify PNG output in `/tmp/slovenia/`
- [x] Verify extent_index.json generation
- [x] Verify data shape (301×401) and value range (12-57 dBZ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)