### PR TITLE
feat: Integrate OMSZ and ARSO into composite with timestamp tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-01-14
+
+### Added
+- Timestamp tolerance matching for composite generation
+  - New `--timestamp-tolerance` argument (default: 2 minutes)
+  - Finds data within time window instead of requiring exact timestamp matches
+  - Better handling of sources with different update intervals
+- ARSO fallback logic for composite command
+  - New `--require-arso` flag to control fallback behavior
+  - Auto-excludes ARSO when no timestamp match (ARSO only provides latest)
+  - ARSO excluded from backload mode (no historical data available)
+- Individual export paths for new sources
+  - `/tmp/slovenia/` for ARSO radar images
+  - `/tmp/hungary/` for OMSZ radar images
+- OMSZ and ARSO added to default composite sources
+
+### Fixed
+- OMSZ timestamp format normalization (`YYYYMMDD_HHMM` → `YYYYMMDDHHMM00`)
+- OMSZ nodata handling: raw value 0 (grey coverage mask) now transparent
+
 ## [1.4.0] - 2026-01-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "1.4.0"
+version = "1.5.0"
 description = "Weather radar data processor for DWD, SHMU, CHMI, ARSO, and OMSZ weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -96,8 +96,8 @@ def create_parser() -> argparse.ArgumentParser:
     composite_parser.add_argument(
         '--sources',
         type=str,
-        default='dwd,shmu,chmi',
-        help='Comma-separated list of sources to merge (default: dwd,shmu,chmi)'
+        default='dwd,shmu,chmi,omsz,arso',
+        help='Comma-separated list of sources to merge (default: dwd,shmu,chmi,omsz,arso)'
     )
     composite_parser.add_argument(
         '--output',
@@ -142,6 +142,17 @@ def create_parser() -> argparse.ArgumentParser:
         '--no-individual',
         action='store_true',
         help='Skip generating individual source images (only create composite)'
+    )
+    composite_parser.add_argument(
+        '--timestamp-tolerance',
+        type=int,
+        default=2,
+        help='Timestamp matching tolerance in minutes (default: 2)'
+    )
+    composite_parser.add_argument(
+        '--require-arso',
+        action='store_true',
+        help='Fail if ARSO data cannot be matched (default: fallback to composite without ARSO)'
     )
 
     return parser


### PR DESCRIPTION
## Summary
- Add OMSZ (Hungary) and ARSO (Slovenia) to default composite sources
- Implement timestamp tolerance matching (±2 min default) for multi-source sync
- Auto-fallback to exclude ARSO when timing mismatch (ARSO only provides latest)
- Fix OMSZ timestamp format and nodata handling

## Changes
- **cli.py**: Add `omsz,arso` to defaults, new `--timestamp-tolerance` and `--require-arso` args
- **cli_composite.py**: New `_find_common_timestamp_with_tolerance()` function, ARSO fallback logic, improved error messages, export paths for Slovenia/Hungary
- **sources/omsz.py**: Timestamp normalization, fix grey mask transparency

## Test plan
- [ ] Run `imeteo-radar composite` with all 5 sources
- [ ] Verify ARSO fallback when timing mismatches
- [ ] Test `--timestamp-tolerance` with different values
- [ ] Verify OMSZ images render without grey mask artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)