### PR TITLE
feat: Add IMGW (Poland) radar data source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.1.1"
+version = "2.2.0"
 description = "Weather radar data processor for DWD, SHMU, CHMI, ARSO, and OMSZ weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/imeteo_radar/__init__.py
+++ b/src/imeteo_radar/__init__.py
@@ -14,6 +14,7 @@ from .processing.merger import RadarMerger
 from .sources.arso import ARSORadarSource
 from .sources.chmi import CHMIRadarSource
 from .sources.dwd import DWDRadarSource
+from .sources.imgw import IMGWRadarSource
 from .sources.omsz import OMSZRadarSource
 
 # Main exports
@@ -25,6 +26,7 @@ __all__ = [
     "CHMIRadarSource",
     "ARSORadarSource",
     "OMSZRadarSource",
+    "IMGWRadarSource",
     "RadarMerger",
     "PNGExporter",
     "RadarAnimator",

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -26,9 +26,9 @@ def create_parser() -> argparse.ArgumentParser:
     )
     fetch_parser.add_argument(
         "--source",
-        choices=["dwd", "shmu", "chmi", "arso", "omsz"],
+        choices=["dwd", "shmu", "chmi", "arso", "omsz", "imgw"],
         default="dwd",
-        help="Radar source (DWD for Germany, SHMU for Slovakia, CHMI for Czechia, ARSO for Slovenia, OMSZ for Hungary)",
+        help="Radar source (DWD for Germany, SHMU for Slovakia, CHMI for Czechia, ARSO for Slovenia, OMSZ for Hungary, IMGW for Poland)",
     )
     fetch_parser.add_argument(
         "--output", type=Path, help="Output directory (default: /tmp/{country}/)"
@@ -66,7 +66,7 @@ def create_parser() -> argparse.ArgumentParser:
     )
     extent_parser.add_argument(
         "--source",
-        choices=["dwd", "shmu", "chmi", "arso", "omsz", "all"],
+        choices=["dwd", "shmu", "chmi", "arso", "omsz", "imgw", "all"],
         default="all",
         help="Radar source(s) to generate extent for",
     )
@@ -81,8 +81,8 @@ def create_parser() -> argparse.ArgumentParser:
     composite_parser.add_argument(
         "--sources",
         type=str,
-        default="dwd,shmu,chmi,omsz,arso",
-        help="Comma-separated list of sources to merge (default: dwd,shmu,chmi,omsz,arso)",
+        default="dwd,shmu,chmi,omsz,arso,imgw",
+        help="Comma-separated list of sources to merge (default: dwd,shmu,chmi,omsz,arso,imgw)",
     )
     composite_parser.add_argument(
         "--output",
@@ -142,7 +142,7 @@ def create_parser() -> argparse.ArgumentParser:
     )
     coverage_parser.add_argument(
         "--source",
-        choices=["dwd", "shmu", "chmi", "arso", "omsz", "all"],
+        choices=["dwd", "shmu", "chmi", "arso", "omsz", "imgw", "all"],
         default="all",
         help="Radar source to generate mask for (default: all)",
     )

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -17,6 +17,7 @@ def composite_command_impl(args: Any) -> int:
         from .sources.arso import ARSORadarSource
         from .sources.chmi import CHMIRadarSource
         from .sources.dwd import DWDRadarSource
+        from .sources.imgw import IMGWRadarSource
         from .sources.omsz import OMSZRadarSource
         from .sources.shmu import SHMURadarSource
 
@@ -42,6 +43,8 @@ def composite_command_impl(args: Any) -> int:
                 sources["arso"] = (ARSORadarSource(), "zm")
             elif source_name == "omsz":
                 sources["omsz"] = (OMSZRadarSource(), "cmax")
+            elif source_name == "imgw":
+                sources["imgw"] = (IMGWRadarSource(), "cmax")
             else:
                 print(f"❌ Unknown source: {source_name}")
                 return 1
@@ -396,6 +399,7 @@ def _export_individual_sources(
         "chmi": Path("/tmp/czechia/"),
         "arso": Path("/tmp/slovenia"),
         "omsz": Path("/tmp/hungary/"),
+        "imgw": Path("/tmp/poland/"),
     }
 
     for source_name, radar_data in sources_data:
@@ -472,6 +476,7 @@ def _export_single_source(
         "chmi": Path("/tmp/czechia/"),
         "arso": Path("/tmp/slovenia/"),
         "omsz": Path("/tmp/hungary/"),
+        "imgw": Path("/tmp/poland/"),
     }
 
     output_dir = source_dirs.get(source_name)

--- a/src/imeteo_radar/config/sources.py
+++ b/src/imeteo_radar/config/sources.py
@@ -54,6 +54,14 @@ SOURCE_REGISTRY: dict[str, dict[str, Any]] = {
         "folder": "hungary",
         "description": "Hungarian Meteorological Service (OMSZ)",
     },
+    "imgw": {
+        "class_name": "IMGWRadarSource",
+        "module": "imeteo_radar.sources.imgw",
+        "product": "cmax",
+        "country": "poland",
+        "folder": "poland",
+        "description": "Polish Institute of Meteorology and Water Management (IMGW)",
+    },
 }
 
 

--- a/src/imeteo_radar/sources/imgw.py
+++ b/src/imeteo_radar/sources/imgw.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""
+IMGW (Polish Institute of Meteorology and Water Management) Radar Source
+
+Handles downloading and processing of IMGW radar data in ODIM_H5 format.
+Data is accessed via the IMGW public API at https://danepubliczne.imgw.pl/api/data/product
+"""
+
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+import pytz
+import requests
+
+from ..core.base import (
+    RadarSource,
+    extract_hdf5_corner_extent,
+    lonlat_to_mercator,
+)
+
+
+class IMGWRadarSource(RadarSource):
+    """IMGW Radar data source implementation"""
+
+    def __init__(self):
+        super().__init__("imgw")
+        # API endpoint for listing available files
+        self.api_url = "https://danepubliczne.imgw.pl/api/data/product/id"
+        # Base URL for actual file downloads (HVD path works, POLCOMP from API doesn't)
+        self.download_base_url = "https://danepubliczne.imgw.pl/pl/datastore/getfiledown/Oper/Polrad/Produkty/HVD"
+
+        # IMGW product mapping (user-facing name -> API product ID and HVD folder name)
+        self.product_mapping = {
+            "cmax": {
+                "api_id": "COMPO_CMAX_250.comp.cmax",  # For API queries
+                "hvd_folder": "HVD_COMPO_CMAX_250.comp.cmax",  # For downloads
+            },
+        }
+
+        # Product metadata
+        self.product_info = {
+            "cmax": {
+                "name": "Composite Maximum Reflectivity (CMAX)",
+                "units": "dBZ",
+                "description": "Column maximum reflectivity composite",
+            }
+        }
+        # temp_files is initialized in base class
+        # Cache for available files from API
+        self._available_files_cache: dict[str, list[dict]] = {}
+
+    def get_available_products(self) -> list[str]:
+        """Get list of available IMGW radar products"""
+        return list(self.product_mapping.keys())
+
+    def get_product_metadata(self, product: str) -> dict[str, Any]:
+        """Get metadata for a specific IMGW product"""
+        if product in self.product_info:
+            return {
+                "product": product,
+                "source": self.name,
+                **self.product_info[product],
+            }
+        return super().get_product_metadata(product)
+
+    def _fetch_available_files(self, product: str) -> list[dict]:
+        """Fetch list of available files from IMGW API
+
+        Args:
+            product: Product name (e.g., 'cmax')
+
+        Returns:
+            List of file dictionaries with 'file' and 'url' keys
+        """
+        if product not in self.product_mapping:
+            raise ValueError(f"Unknown product: {product}")
+
+        # Check cache first
+        if product in self._available_files_cache:
+            return self._available_files_cache[product]
+
+        product_config = self.product_mapping[product]
+        api_endpoint = f"{self.api_url}/{product_config['api_id']}"
+
+        try:
+            response = requests.get(api_endpoint, timeout=30)
+            response.raise_for_status()
+            files = response.json()
+
+            # Filter to only H5 files
+            h5_files = [f for f in files if f["file"].endswith(".h5")]
+
+            # Cache the result
+            self._available_files_cache[product] = h5_files
+
+            return h5_files
+        except Exception as e:
+            print(f"⚠️  Failed to fetch file list from API: {e}")
+            return []
+
+    def _extract_timestamp_from_filename(self, filename: str) -> str | None:
+        """Extract timestamp from IMGW filename
+
+        Filename format: YYYYMMDDHHMMSS00dBZ.cmax.h5
+        Returns: YYYYMMDDHHMMSS (14 digits)
+        """
+        # Remove file extension and suffix
+        # Example: 2026012705300000dBZ.cmax.h5 -> 20260127053000
+        try:
+            # Extract digits before "00dBZ"
+            ts_part = filename.split("00dBZ")[0]
+            if len(ts_part) == 14 and ts_part.isdigit():
+                return ts_part
+        except Exception:
+            pass
+        return None
+
+    def _generate_timestamps(self, count: int) -> list[str]:
+        """Generate recent timestamps to search for available data
+
+        IMGW updates every 5 minutes. Generate timestamps starting from
+        current UTC time and working backwards.
+        """
+        from datetime import timedelta
+
+        timestamps = []
+        current_time = datetime.now(pytz.UTC)
+
+        # Start from current time and work backwards in 5-minute intervals
+        # IMGW files are typically available with ~10 minute delay
+        for minutes_back in range(10, count * 30, 5):
+            check_time = current_time - timedelta(minutes=minutes_back)
+            # Round down to nearest 5 minutes
+            check_time = check_time.replace(
+                minute=(check_time.minute // 5) * 5, second=0, microsecond=0
+            )
+            timestamp = check_time.strftime("%Y%m%d%H%M%S")
+
+            if timestamp not in timestamps:
+                timestamps.append(timestamp)
+
+        return timestamps
+
+    def _check_timestamp_availability(self, timestamp: str, product: str) -> bool:
+        """Check if data is available for a specific timestamp and product
+
+        Uses HEAD request to check if the file exists on the server.
+        """
+        try:
+            url = self._get_product_url(timestamp, product)
+            response = requests.head(url, timeout=10)
+            # Check if it's a real file (not HTML error page)
+            content_type = response.headers.get("Content-Type", "")
+            return response.status_code == 200 and "text/html" not in content_type
+        except Exception:
+            return False
+
+    def _get_product_url(self, timestamp: str, product: str) -> str:
+        """Generate download URL for IMGW product
+
+        Uses HVD path which works for actual file downloads.
+        The API returns POLCOMP URLs but those return HTML, not actual files.
+        """
+        if product not in self.product_mapping:
+            raise ValueError(f"Unknown product: {product}")
+
+        product_config = self.product_mapping[product]
+        hvd_folder = product_config["hvd_folder"]
+        return f"{self.download_base_url}/{hvd_folder}/{timestamp}00dBZ.cmax.h5"
+
+    def _filter_timestamps_by_range(
+        self, timestamps: list[str], start_time: datetime, end_time: datetime
+    ) -> list[str]:
+        """Filter timestamps to only include those within the specified time range
+
+        Args:
+            timestamps: List of timestamp strings in format YYYYMMDDHHMMSS (14 digits)
+            start_time: Start of time range (timezone-aware datetime)
+            end_time: End of time range (timezone-aware datetime)
+
+        Returns:
+            Filtered list of timestamps within the range
+        """
+        filtered = []
+        for ts in timestamps:
+            try:
+                # Parse IMGW timestamp format: YYYYMMDDHHMMSS (14 digits)
+                ts_dt = datetime.strptime(ts, "%Y%m%d%H%M%S")
+                # Make timezone aware (IMGW uses UTC)
+                ts_dt = pytz.UTC.localize(ts_dt)
+
+                # Check if timestamp is within range
+                if start_time <= ts_dt <= end_time:
+                    filtered.append(ts)
+            except ValueError:
+                # Skip timestamps that can't be parsed
+                continue
+
+        return filtered
+
+    def _download_single_file(
+        self, timestamp: str, product: str, url: str | None = None
+    ) -> dict[str, Any]:
+        """Download a single radar file (for parallel processing)"""
+        if product not in self.product_mapping:
+            return {
+                "error": f"Unknown product: {product}",
+                "timestamp": timestamp,
+                "product": product,
+                "success": False,
+            }
+
+        try:
+            # Check if we've already downloaded this file in this session
+            cache_key = f"{timestamp}_{product}"
+            if cache_key in self.temp_files:
+                return {
+                    "timestamp": timestamp,
+                    "product": product,
+                    "path": self.temp_files[cache_key],
+                    "url": url or self._get_product_url(timestamp, product),
+                    "cached": True,
+                    "success": True,
+                }
+
+            # Get download URL
+            if url is None:
+                url = self._get_product_url(timestamp, product)
+
+            # Create a proper temporary file
+            with tempfile.NamedTemporaryFile(
+                suffix=f"_imgw_{product}_{timestamp}.h5", delete=False
+            ) as temp_file:
+                # Download directly to temp file
+                response = requests.get(url, timeout=60)
+                response.raise_for_status()
+
+                # Verify we got actual HDF5 data, not HTML
+                content = response.content
+                if content[:4] == b"<!DO" or content[:5] == b"<html":
+                    return {
+                        "error": "Server returned HTML instead of HDF5 data",
+                        "timestamp": timestamp,
+                        "product": product,
+                        "success": False,
+                    }
+
+                temp_file.write(content)
+                temp_path = Path(temp_file.name)
+
+            # Track the temporary file
+            self.temp_files[cache_key] = str(temp_path)
+
+            return {
+                "timestamp": timestamp,
+                "product": product,
+                "path": str(temp_path),
+                "url": url,
+                "cached": False,
+                "success": True,
+            }
+
+        except Exception as e:
+            return {
+                "error": str(e),
+                "timestamp": timestamp,
+                "product": product,
+                "success": False,
+            }
+
+    def download_latest(
+        self,
+        count: int,
+        products: list[str] | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """Download latest IMGW radar data
+
+        Args:
+            count: Maximum number of timestamps to download
+            products: List of products to download (default: ['cmax'])
+            start_time: Optional start time for filtering (timezone-aware datetime)
+            end_time: Optional end time for filtering (timezone-aware datetime)
+        """
+
+        if products is None:
+            products = ["cmax"]  # Default product
+
+        print(f"🔍 Finding last {count} available IMGW timestamps...")
+
+        # Generate timestamps based on current time (like SHMU/CHMI)
+        print("🌐 Checking IMGW server for current timestamps...")
+
+        # Generate more timestamps if we're filtering by time range
+        multiplier = 8 if (start_time and end_time) else 4
+        test_timestamps = self._generate_timestamps(count * multiplier)
+
+        # Filter by time range if specified
+        if start_time and end_time:
+            test_timestamps = self._filter_timestamps_by_range(
+                test_timestamps, start_time, end_time
+            )
+            print(
+                f"📅 Filtered to range: {start_time.strftime('%Y-%m-%d %H:%M')} to {end_time.strftime('%Y-%m-%d %H:%M')}"
+            )
+
+        # Check which timestamps are available
+        available_timestamps = []
+        for timestamp in test_timestamps:
+            if len(available_timestamps) >= count:
+                break
+
+            # Check availability via HEAD request
+            if self._check_timestamp_availability(timestamp, "cmax"):
+                available_timestamps.append(timestamp)
+                print(f"✅ Found current: {timestamp}")
+
+        if not available_timestamps:
+            print("❌ No available timestamps found")
+            return []
+
+        print(
+            f"📥 Downloading {len(available_timestamps)} timestamps × {len(products)} products..."
+        )
+
+        # Create download tasks
+        download_tasks = []
+        for timestamp in available_timestamps:
+            for product in products:
+                url = self._get_product_url(timestamp, product)
+                download_tasks.append((timestamp, product, url))
+
+        print(
+            f"📥 Starting parallel downloads ({len(download_tasks)} files, max 6 concurrent)..."
+        )
+
+        # Execute downloads in parallel
+        downloaded_files = []
+        with ThreadPoolExecutor(max_workers=6) as executor:
+            # Submit all download tasks
+            future_to_task = {
+                executor.submit(
+                    self._download_single_file, timestamp, product, url
+                ): (timestamp, product)
+                for timestamp, product, url in download_tasks
+            }
+
+            # Process completed downloads
+            for future in as_completed(future_to_task):
+                timestamp, product = future_to_task[future]
+                try:
+                    result = future.result()
+                    if result["success"]:
+                        downloaded_files.append(result)
+                        if result["cached"]:
+                            print(f"📁 Using cached: {product} {timestamp}")
+                        else:
+                            print(f"✅ Downloaded: {product} {timestamp}")
+                    else:
+                        print(
+                            f"❌ Failed {product} {timestamp}: {result.get('error', 'Unknown error')}"
+                        )
+                except Exception as e:
+                    print(f"❌ Exception {product} {timestamp}: {e}")
+
+        print(
+            f"📋 IMGW: Downloaded {len(downloaded_files)} files ({len(download_tasks) - len(downloaded_files)} failed)"
+        )
+        return downloaded_files
+
+    def process_to_array(self, file_path: str) -> dict[str, Any]:
+        """Process IMGW HDF5 file to array with metadata
+
+        IMGW uses ODIM_H5/V2_3 format with structure:
+        - dataset1/data1/data: raw uint8 data
+        - dataset1/what: scaling info (gain, offset, nodata, etc.)
+        - where: corner coordinates (LL, LR, UL, UR)
+        - what: global metadata (date, time, source)
+        """
+
+        try:
+            with h5py.File(file_path, "r") as f:
+                # Read raw data
+                data = f["dataset1/data1/data"][:]
+
+                # Get attributes - IMGW stores scaling in dataset1/what (NOT data1/what)
+                what_attrs = dict(f["dataset1/what"].attrs)
+                what_global = dict(f["what"].attrs)  # Global metadata
+                where_attrs = dict(f["where"].attrs)
+
+                # Decode byte strings
+                for attr_dict in [what_attrs, what_global, where_attrs]:
+                    for key, value in attr_dict.items():
+                        if isinstance(value, bytes):
+                            attr_dict[key] = value.decode("utf-8")
+
+                # Apply scaling (from dataset1/what)
+                gain = what_attrs.get("gain", 0.5)
+                offset = what_attrs.get("offset", -32.0)
+                nodata = what_attrs.get("nodata", 255.0)
+                undetect = what_attrs.get("undetect", 0.0)
+
+                # Scale data
+                scaled_data = data.astype(np.float32) * gain + offset
+
+                # Handle special values
+                scaled_data[data == int(nodata)] = np.nan
+                scaled_data[data == int(undetect)] = np.nan
+
+                # Get corner coordinates from where attributes
+                # IMGW uses LL (lower-left), UR (upper-right) pattern
+                if "LL_lon" in where_attrs and "UR_lon" in where_attrs:
+                    ll_lon = float(where_attrs["LL_lon"])
+                    ll_lat = float(where_attrs["LL_lat"])
+                    ur_lon = float(where_attrs["UR_lon"])
+                    ur_lat = float(where_attrs["UR_lat"])
+                else:
+                    # Fallback: approximate Poland coverage
+                    print(
+                        "⚠️  Corner coordinates not found in HDF5, using approximate extent"
+                    )
+                    ll_lon, ll_lat = 13.0, 48.1
+                    ur_lon, ur_lat = 26.4, 56.2
+
+                lons = np.linspace(ll_lon, ur_lon, data.shape[1])
+                lats = np.linspace(ur_lat, ll_lat, data.shape[0])  # Note: flipped
+
+                # Extract metadata
+                product = what_attrs.get("product", "MAX")
+                quantity = what_attrs.get("quantity", "DBZH")
+                start_date = what_attrs.get("startdate", what_global.get("date", ""))
+                start_time_str = what_attrs.get("starttime", what_global.get("time", ""))
+                timestamp = str(start_date) + str(start_time_str)
+
+                return {
+                    "data": scaled_data,
+                    "coordinates": {"lons": lons, "lats": lats},
+                    "metadata": {
+                        "product": product,
+                        "quantity": quantity,
+                        "timestamp": timestamp,
+                        "source": "IMGW",
+                        "units": self._get_units(quantity),
+                        "nodata_value": np.nan,
+                        "gain": gain,
+                        "offset": offset,
+                    },
+                    "extent": {
+                        "wgs84": {
+                            "west": ll_lon,
+                            "east": ur_lon,
+                            "south": ll_lat,
+                            "north": ur_lat,
+                        }
+                    },
+                    "dimensions": data.shape,
+                    "timestamp": (
+                        timestamp[:14] if len(timestamp) >= 14 else timestamp
+                    ),  # YYYYMMDDHHMMSS format
+                }
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to process IMGW file {file_path}: {e}")
+
+    def _get_units(self, quantity: str) -> str:
+        """Get units for a quantity"""
+        units_map = {"DBZH": "dBZ", "TH": "dBZ"}
+        return units_map.get(quantity, "dBZ")  # Default to dBZ for reflectivity
+
+    def get_extent(self) -> dict[str, Any]:
+        """Get IMGW radar coverage extent"""
+
+        # IMGW radar coverage (from actual HDF5 data)
+        # Covers Poland and surrounding areas
+        wgs84 = {"west": 13.0, "east": 26.4, "south": 48.1, "north": 56.2}
+
+        # Convert to Web Mercator
+        x_min, y_min = lonlat_to_mercator(wgs84["west"], wgs84["south"])
+        x_max, y_max = lonlat_to_mercator(wgs84["east"], wgs84["north"])
+
+        return {
+            "wgs84": wgs84,
+            "mercator": {
+                "x_min": x_min,
+                "x_max": x_max,
+                "y_min": y_min,
+                "y_max": y_max,
+                "bounds": [x_min, y_min, x_max, y_max],  # [xmin, ymin, xmax, ymax]
+            },
+            "projection": "EPSG:3857",  # Web Mercator
+            "grid_size": None,  # To be determined from actual data
+            "resolution_m": None,  # To be determined from actual data
+        }
+
+    def extract_extent_only(self, file_path: str) -> dict[str, Any]:
+        """Extract extent from IMGW HDF5 without loading data array.
+
+        Uses shared HDF5 corner extraction from base module with Poland fallback.
+        """
+        # Fallback extent for Poland (from actual IMGW data)
+        fallback = {"west": 13.0, "east": 26.4, "south": 48.1, "north": 56.2}
+        return extract_hdf5_corner_extent(file_path, fallback_extent=fallback)
+
+    # cleanup_temp_files() is inherited from RadarSource base class

--- a/tests/test_imgw.py
+++ b/tests/test_imgw.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""
+Unit tests for IMGW (Polish Institute of Meteorology and Water Management) Radar Source
+
+Tests follow TDD methodology - written before implementation.
+"""
+
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import h5py
+import numpy as np
+import pytest
+import pytz
+
+
+class TestIMGWRadarSourceInitialization:
+    """Test IMGW source initialization"""
+
+    def test_imgw_source_initializes_with_correct_name(self):
+        """Test that IMGW source initializes with name 'imgw'"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        assert source.name == "imgw"
+
+    def test_imgw_source_has_correct_base_url(self):
+        """Test that IMGW source has correct API and download URLs"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        assert "danepubliczne.imgw.pl" in source.api_url
+        assert "danepubliczne.imgw.pl" in source.download_base_url
+        assert "HVD" in source.download_base_url
+
+    def test_imgw_source_has_temp_files_dict(self):
+        """Test that IMGW source initializes with empty temp_files dict"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        assert isinstance(source.temp_files, dict)
+        assert len(source.temp_files) == 0
+
+    def test_imgw_source_has_product_mapping(self):
+        """Test that IMGW source has product mapping with cmax"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        assert hasattr(source, "product_mapping")
+        assert "cmax" in source.product_mapping
+
+
+class TestIMGWProducts:
+    """Test IMGW product-related methods"""
+
+    def test_get_available_products_returns_list(self):
+        """Test that get_available_products returns a list"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        products = source.get_available_products()
+        assert isinstance(products, list)
+
+    def test_get_available_products_includes_cmax(self):
+        """Test that available products include cmax"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        products = source.get_available_products()
+        assert "cmax" in products
+
+    def test_get_product_metadata_returns_dict(self):
+        """Test that get_product_metadata returns a dictionary"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        metadata = source.get_product_metadata("cmax")
+        assert isinstance(metadata, dict)
+
+    def test_get_product_metadata_includes_required_fields(self):
+        """Test that product metadata includes required fields"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        metadata = source.get_product_metadata("cmax")
+        assert "product" in metadata
+        assert "source" in metadata
+        assert metadata["source"] == "imgw"
+
+
+class TestIMGWTimestamps:
+    """Test IMGW timestamp generation"""
+
+    def test_generate_timestamps_returns_list(self):
+        """Test that _generate_timestamps returns a list"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        timestamps = source._generate_timestamps(3)
+        assert isinstance(timestamps, list)
+
+    def test_generate_timestamps_returns_correct_count(self):
+        """Test that _generate_timestamps returns expected number of timestamps"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        timestamps = source._generate_timestamps(3)
+        # Should return at least count * 4 to account for missing data
+        assert len(timestamps) >= 3
+
+    def test_generate_timestamps_format_is_14_digits(self):
+        """Test that timestamps are 14 digits (YYYYMMDDHHMMSS)"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        timestamps = source._generate_timestamps(3)
+        for ts in timestamps:
+            assert len(ts) == 14
+            assert ts.isdigit()
+
+    def test_generate_timestamps_are_5_minute_intervals(self):
+        """Test that timestamps are at 5-minute intervals"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        timestamps = source._generate_timestamps(5)
+        for ts in timestamps:
+            # Extract minutes
+            minutes = int(ts[10:12])
+            assert minutes % 5 == 0
+
+    def test_generate_timestamps_are_unique(self):
+        """Test that generated timestamps are unique"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        timestamps = source._generate_timestamps(10)
+        assert len(timestamps) == len(set(timestamps))
+
+
+class TestIMGWUrlGeneration:
+    """Test IMGW URL generation"""
+
+    def test_get_product_url_contains_base_url(self):
+        """Test that generated URL contains base URL"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        url = source._get_product_url("20250127120000", "cmax")
+        assert "danepubliczne.imgw.pl" in url
+
+    def test_get_product_url_contains_product_directory(self):
+        """Test that generated URL contains product directory"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        url = source._get_product_url("20250127120000", "cmax")
+        assert "HVD_COMPO_CMAX_250" in url
+
+    def test_get_product_url_contains_timestamp(self):
+        """Test that generated URL contains timestamp"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        url = source._get_product_url("20250127120000", "cmax")
+        assert "20250127120000" in url
+
+    def test_get_product_url_ends_with_h5(self):
+        """Test that generated URL ends with .h5"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        url = source._get_product_url("20250127120000", "cmax")
+        assert url.endswith(".h5")
+
+    def test_get_product_url_has_dbz_suffix(self):
+        """Test that generated URL contains 00dBZ suffix pattern"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        url = source._get_product_url("20250127120000", "cmax")
+        assert "00dBZ" in url
+
+    def test_get_product_url_raises_for_unknown_product(self):
+        """Test that _get_product_url raises for unknown product"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        with pytest.raises(ValueError):
+            source._get_product_url("20250127120000", "unknown_product")
+
+
+class TestIMGWAvailability:
+    """Test IMGW timestamp availability checking via HEAD requests"""
+
+    @patch("requests.head")
+    def test_check_timestamp_availability_returns_true_when_file_exists(self, mock_head):
+        """Test that availability check returns True when HEAD request succeeds with non-HTML content"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        # Mock successful HEAD response (non-HTML content type indicates real file)
+        mock_head.return_value.status_code = 200
+        mock_head.return_value.headers = {"Content-Type": "application/octet-stream"}
+
+        source = IMGWRadarSource()
+        result = source._check_timestamp_availability("20250127120000", "cmax")
+        assert result is True
+
+    @patch("requests.head")
+    def test_check_timestamp_availability_returns_false_when_file_missing(self, mock_head):
+        """Test that availability check returns False when server returns HTML (error page)"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        # Mock response that returns HTML (indicates error/404 page)
+        mock_head.return_value.status_code = 200
+        mock_head.return_value.headers = {"Content-Type": "text/html"}
+
+        source = IMGWRadarSource()
+        result = source._check_timestamp_availability("20250127120000", "cmax")
+        assert result is False
+
+    @patch("requests.head")
+    def test_check_timestamp_availability_returns_false_on_exception(self, mock_head):
+        """Test that availability check returns False on exception"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        mock_head.side_effect = Exception("Network error")
+        source = IMGWRadarSource()
+        result = source._check_timestamp_availability("20250127120000", "cmax")
+        assert result is False
+
+
+class TestIMGWDownload:
+    """Test IMGW file download functionality"""
+
+    @patch("requests.get")
+    def test_download_single_file_returns_dict(self, mock_get):
+        """Test that _download_single_file returns a dictionary"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        mock_get.return_value.content = b"test content"
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        source = IMGWRadarSource()
+        result = source._download_single_file("20250127120000", "cmax")
+        assert isinstance(result, dict)
+
+    @patch("requests.get")
+    def test_download_single_file_includes_required_keys(self, mock_get):
+        """Test that download result includes required keys"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        mock_get.return_value.content = b"test content"
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        source = IMGWRadarSource()
+        result = source._download_single_file("20250127120000", "cmax")
+
+        assert "timestamp" in result
+        assert "product" in result
+        assert "success" in result
+
+    @patch("requests.get")
+    def test_download_single_file_success_flag(self, mock_get):
+        """Test that successful download has success=True"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        mock_get.return_value.content = b"test content"
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        source = IMGWRadarSource()
+        result = source._download_single_file("20250127120000", "cmax")
+        assert result["success"] is True
+
+    @patch("requests.get")
+    def test_download_single_file_caches_file(self, mock_get):
+        """Test that downloaded files are cached"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        mock_get.return_value.content = b"test content"
+        mock_get.return_value.raise_for_status = MagicMock()
+
+        source = IMGWRadarSource()
+        result1 = source._download_single_file("20250127120000", "cmax")
+        result2 = source._download_single_file("20250127120000", "cmax")
+
+        # Second call should use cache
+        assert result2.get("cached", False) is True
+
+        # Clean up
+        source.cleanup_temp_files()
+
+    def test_download_single_file_returns_error_for_unknown_product(self):
+        """Test that unknown product returns error"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source._download_single_file("20250127120000", "unknown_product")
+        assert result["success"] is False
+        assert "error" in result
+
+
+class TestIMGWProcessing:
+    """Test IMGW HDF5 file processing"""
+
+    @pytest.fixture
+    def mock_hdf5_file(self, tmp_path):
+        """Create a mock HDF5 file with IMGW-like structure
+
+        IMGW ODIM_H5 structure:
+        - dataset1/data1/data: raw uint8 data
+        - dataset1/what: scaling info (gain, offset, nodata, undetect, quantity, product, startdate, starttime)
+        - what: global metadata (date, time, source)
+        - where: corner coordinates (LL_lon, LL_lat, UR_lon, UR_lat)
+        """
+        file_path = tmp_path / "test_imgw.h5"
+
+        with h5py.File(file_path, "w") as f:
+            # Create data with realistic shape
+            data = np.random.randint(0, 255, (500, 600), dtype=np.uint8)
+
+            # Create dataset structure
+            dataset1 = f.create_group("dataset1")
+            data1 = dataset1.create_group("data1")
+            data1.create_dataset("data", data=data)
+
+            # Add dataset1/what attributes - IMGW stores scaling AND product info here
+            what_dataset = dataset1.create_group("what")
+            what_dataset.attrs["gain"] = 0.5
+            what_dataset.attrs["offset"] = -32.0
+            what_dataset.attrs["nodata"] = 255.0
+            what_dataset.attrs["undetect"] = 0.0
+            what_dataset.attrs["quantity"] = b"DBZH"
+            what_dataset.attrs["product"] = b"COMP"
+            what_dataset.attrs["startdate"] = b"20250127"
+            what_dataset.attrs["starttime"] = b"120000"
+
+            # Add global what attributes (fallback metadata)
+            what_global = f.create_group("what")
+            what_global.attrs["date"] = b"20250127"
+            what_global.attrs["time"] = b"120000"
+            what_global.attrs["source"] = b"IMGW"
+
+            # Add where attributes (extent)
+            where = f.create_group("where")
+            where.attrs["LL_lon"] = 14.0
+            where.attrs["LL_lat"] = 49.0
+            where.attrs["UR_lon"] = 24.3
+            where.attrs["UR_lat"] = 54.9
+
+        return str(file_path)
+
+    def test_process_to_array_returns_dict(self, mock_hdf5_file):
+        """Test that process_to_array returns a dictionary"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        assert isinstance(result, dict)
+
+    def test_process_to_array_includes_data_array(self, mock_hdf5_file):
+        """Test that processed result includes data array"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        assert "data" in result
+        assert isinstance(result["data"], np.ndarray)
+
+    def test_process_to_array_includes_coordinates(self, mock_hdf5_file):
+        """Test that processed result includes coordinates"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        assert "coordinates" in result
+        assert "lons" in result["coordinates"]
+        assert "lats" in result["coordinates"]
+
+    def test_process_to_array_includes_metadata(self, mock_hdf5_file):
+        """Test that processed result includes metadata"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        assert "metadata" in result
+        assert "source" in result["metadata"]
+        assert result["metadata"]["source"] == "IMGW"
+
+    def test_process_to_array_includes_extent(self, mock_hdf5_file):
+        """Test that processed result includes extent"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        assert "extent" in result
+        assert "wgs84" in result["extent"]
+
+    def test_process_to_array_applies_scaling(self, mock_hdf5_file):
+        """Test that data scaling is applied correctly"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.process_to_array(mock_hdf5_file)
+        # Data should be scaled (gain=0.5, offset=-32)
+        # So values should be in dBZ range, not raw uint8 0-255
+        data = result["data"]
+        valid_data = data[~np.isnan(data)]
+        if len(valid_data) > 0:
+            # Scaled data should be in reasonable dBZ range
+            assert np.min(valid_data) >= -50  # Min reasonable dBZ
+            assert np.max(valid_data) <= 100  # Max reasonable dBZ
+
+
+class TestIMGWExtent:
+    """Test IMGW extent methods"""
+
+    def test_get_extent_returns_dict(self):
+        """Test that get_extent returns a dictionary"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        extent = source.get_extent()
+        assert isinstance(extent, dict)
+
+    def test_get_extent_includes_wgs84(self):
+        """Test that extent includes WGS84 bounds"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        extent = source.get_extent()
+        assert "wgs84" in extent
+        assert "west" in extent["wgs84"]
+        assert "east" in extent["wgs84"]
+        assert "south" in extent["wgs84"]
+        assert "north" in extent["wgs84"]
+
+    def test_get_extent_covers_poland(self):
+        """Test that extent covers Poland's approximate bounds"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        extent = source.get_extent()
+        wgs84 = extent["wgs84"]
+
+        # Poland approximate bounds: 14.0-24.3E, 49.0-54.9N
+        assert wgs84["west"] <= 14.5  # Should include western Poland
+        assert wgs84["east"] >= 24.0  # Should include eastern Poland
+        assert wgs84["south"] <= 49.5  # Should include southern Poland
+        assert wgs84["north"] >= 54.5  # Should include northern Poland
+
+    def test_get_extent_includes_mercator(self):
+        """Test that extent includes Mercator projection"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        extent = source.get_extent()
+        assert "mercator" in extent
+        assert "x_min" in extent["mercator"]
+        assert "x_max" in extent["mercator"]
+        assert "y_min" in extent["mercator"]
+        assert "y_max" in extent["mercator"]
+
+
+class TestIMGWMemoryOptimization:
+    """Test IMGW memory-efficient extent extraction"""
+
+    @pytest.fixture
+    def mock_hdf5_file(self, tmp_path):
+        """Create a mock HDF5 file for extent extraction"""
+        file_path = tmp_path / "test_imgw_extent.h5"
+
+        with h5py.File(file_path, "w") as f:
+            # Create minimal data structure
+            data = np.zeros((100, 100), dtype=np.uint8)
+            dataset1 = f.create_group("dataset1")
+            data1 = dataset1.create_group("data1")
+            data1.create_dataset("data", data=data)
+
+            # Add where attributes (extent)
+            where = f.create_group("where")
+            where.attrs["LL_lon"] = 14.0
+            where.attrs["LL_lat"] = 49.0
+            where.attrs["UR_lon"] = 24.3
+            where.attrs["UR_lat"] = 54.9
+
+        return str(file_path)
+
+    def test_extract_extent_only_returns_dict(self, mock_hdf5_file):
+        """Test that extract_extent_only returns a dictionary"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.extract_extent_only(mock_hdf5_file)
+        assert isinstance(result, dict)
+
+    def test_extract_extent_only_includes_extent(self, mock_hdf5_file):
+        """Test that result includes extent"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.extract_extent_only(mock_hdf5_file)
+        assert "extent" in result
+        assert "wgs84" in result["extent"]
+
+    def test_extract_extent_only_includes_dimensions(self, mock_hdf5_file):
+        """Test that result includes dimensions"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        result = source.extract_extent_only(mock_hdf5_file)
+        assert "dimensions" in result
+        assert result["dimensions"] == (100, 100)
+
+
+class TestIMGWRegistry:
+    """Test IMGW integration with source registry"""
+
+    def test_imgw_in_source_registry(self):
+        """Test that imgw is registered in SOURCE_REGISTRY"""
+        from imeteo_radar.config.sources import SOURCE_REGISTRY
+
+        assert "imgw" in SOURCE_REGISTRY
+
+    def test_imgw_registry_has_correct_class(self):
+        """Test that imgw registry entry has correct class name"""
+        from imeteo_radar.config.sources import SOURCE_REGISTRY
+
+        assert SOURCE_REGISTRY["imgw"]["class_name"] == "IMGWRadarSource"
+
+    def test_imgw_registry_has_correct_module(self):
+        """Test that imgw registry entry has correct module path"""
+        from imeteo_radar.config.sources import SOURCE_REGISTRY
+
+        assert SOURCE_REGISTRY["imgw"]["module"] == "imeteo_radar.sources.imgw"
+
+    def test_imgw_registry_has_correct_product(self):
+        """Test that imgw registry entry has correct default product"""
+        from imeteo_radar.config.sources import SOURCE_REGISTRY
+
+        assert SOURCE_REGISTRY["imgw"]["product"] == "cmax"
+
+    def test_imgw_registry_has_correct_country(self):
+        """Test that imgw registry entry has correct country"""
+        from imeteo_radar.config.sources import SOURCE_REGISTRY
+
+        assert SOURCE_REGISTRY["imgw"]["country"] == "poland"
+
+    def test_get_source_instance_returns_imgw(self):
+        """Test that get_source_instance creates IMGWRadarSource"""
+        from imeteo_radar.config.sources import get_source_instance
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = get_source_instance("imgw")
+        assert isinstance(source, IMGWRadarSource)
+
+
+class TestIMGWCLI:
+    """Test IMGW CLI integration"""
+
+    def test_imgw_in_fetch_choices(self):
+        """Test that imgw is available in fetch command choices"""
+        from imeteo_radar.cli import create_parser
+
+        parser = create_parser()
+        # Get fetch subparser
+        fetch_action = None
+        for action in parser._subparsers._actions:
+            if (
+                hasattr(action, "choices")
+                and action.choices
+                and "fetch" in action.choices
+            ):
+                fetch_action = action.choices["fetch"]
+                break
+
+        assert fetch_action is not None
+        # Check source argument choices
+        found = False
+        for action in fetch_action._actions:
+            if hasattr(action, "dest") and action.dest == "source":
+                assert "imgw" in action.choices
+                found = True
+                break
+        assert found, "source argument not found in fetch parser"
+
+    def test_imgw_in_extent_choices(self):
+        """Test that imgw is available in extent command choices"""
+        from imeteo_radar.cli import create_parser
+
+        parser = create_parser()
+        # Get extent subparser
+        extent_action = None
+        for action in parser._subparsers._actions:
+            if (
+                hasattr(action, "choices")
+                and action.choices
+                and "extent" in action.choices
+            ):
+                extent_action = action.choices["extent"]
+                break
+
+        assert extent_action is not None
+        # Check source argument choices
+        found = False
+        for action in extent_action._actions:
+            if hasattr(action, "dest") and action.dest == "source":
+                assert "imgw" in action.choices
+                found = True
+                break
+        assert found, "source argument not found in extent parser"
+
+    def test_imgw_in_coverage_mask_choices(self):
+        """Test that imgw is available in coverage-mask command choices"""
+        from imeteo_radar.cli import create_parser
+
+        parser = create_parser()
+        # Get coverage-mask subparser
+        coverage_action = None
+        for action in parser._subparsers._actions:
+            if (
+                hasattr(action, "choices")
+                and action.choices
+                and "coverage-mask" in action.choices
+            ):
+                coverage_action = action.choices["coverage-mask"]
+                break
+
+        assert coverage_action is not None
+        # Check source argument choices
+        found = False
+        for action in coverage_action._actions:
+            if hasattr(action, "dest") and action.dest == "source":
+                assert "imgw" in action.choices
+                found = True
+                break
+        assert found, "source argument not found in coverage-mask parser"
+
+
+class TestIMGWPackageExport:
+    """Test IMGW package-level exports"""
+
+    def test_imgw_source_in_all(self):
+        """Test that IMGWRadarSource is in __all__"""
+        from imeteo_radar import __all__
+
+        assert "IMGWRadarSource" in __all__
+
+    def test_imgw_source_importable_from_package(self):
+        """Test that IMGWRadarSource can be imported from package"""
+        from imeteo_radar import IMGWRadarSource
+
+        assert IMGWRadarSource is not None
+
+    def test_imgw_source_is_correct_class(self):
+        """Test that imported IMGWRadarSource is the correct class"""
+        from imeteo_radar import IMGWRadarSource
+        from imeteo_radar.core.base import RadarSource
+
+        assert issubclass(IMGWRadarSource, RadarSource)
+
+
+class TestIMGWFilterTimestamps:
+    """Test IMGW timestamp filtering by time range"""
+
+    def test_filter_timestamps_by_range_returns_list(self):
+        """Test that _filter_timestamps_by_range returns a list"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        start = datetime(2025, 1, 27, 10, 0, tzinfo=pytz.UTC)
+        end = datetime(2025, 1, 27, 12, 0, tzinfo=pytz.UTC)
+        timestamps = ["20250127100000", "20250127110000", "20250127120000"]
+
+        result = source._filter_timestamps_by_range(timestamps, start, end)
+        assert isinstance(result, list)
+
+    def test_filter_timestamps_by_range_filters_correctly(self):
+        """Test that timestamps outside range are filtered out"""
+        from imeteo_radar.sources.imgw import IMGWRadarSource
+
+        source = IMGWRadarSource()
+        start = datetime(2025, 1, 27, 10, 0, tzinfo=pytz.UTC)
+        end = datetime(2025, 1, 27, 11, 0, tzinfo=pytz.UTC)
+        timestamps = [
+            "20250127090000",  # Before range
+            "20250127100000",  # In range
+            "20250127103000",  # In range
+            "20250127110000",  # In range
+            "20250127120000",  # After range
+        ]
+
+        result = source._filter_timestamps_by_range(timestamps, start, end)
+        assert "20250127090000" not in result
+        assert "20250127100000" in result
+        assert "20250127103000" in result
+        assert "20250127110000" in result
+        assert "20250127120000" not in result


### PR DESCRIPTION
## Summary

Add support for IMGW (Polish Institute of Meteorology and Water Management) as a new radar data source, bringing the total to **6 supported radar sources**.

### Changes

- **New source implementation** (`src/imeteo_radar/sources/imgw.py`)
  - IMGWRadarSource class with ODIM_H5 format support
  - Data fetched from danepubliczne.imgw.pl public API
  - Timestamp generation based on current UTC time
  - HEAD request availability checking (API listing lags behind actual file availability)
  - 5-minute update interval
  - Poland coverage: 13.0-26.4°E, 48.1-56.2°N

- **CLI integration**
  - Added `imgw` to fetch, extent, and coverage-mask commands
  - Included in composite command default sources
  - Poland output directory: `/tmp/poland/`

- **Configuration**
  - Registered in SOURCE_REGISTRY with 'poland' country/folder
  - Exported IMGWRadarSource from package

- **Testing**
  - 54 unit tests covering all functionality

### Version

2.1.1 → 2.2.0 (new feature)

## Test Plan

- [x] All 54 IMGW tests pass
- [x] `imeteo-radar fetch --source imgw` downloads and processes data
- [x] `imeteo-radar composite` includes IMGW and creates Poland output
- [x] Timestamps match other European sources (within 2-minute tolerance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)