### PR TITLE
feat: Cache-aware downloading with dual-layer cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-01-28
+
+### Added
+- **Cache-aware downloading**: Skip downloads for timestamps already in cache
+  - Query providers for available timestamps without downloading
+  - Check cache before deciding what to download
+  - ~90% reduction in redundant downloads per run
+  - Enhanced logging: "DWD: 8 available, 7 in cache, 1 to download"
+
+- **Dual-layer processed data cache** (`ProcessedDataCache`)
+  - Layer 1: Local filesystem (/tmp/iradar-data) - fast, ephemeral
+  - Layer 2: S3/DO Spaces - persistent across pod restarts
+  - TTL-based expiration (60 minutes default)
+  - Automatic cleanup of expired entries
+
+- **S3 composite existence check**: Prevent regenerating composites after pod restart
+  - Check S3 before processing if local file doesn't exist
+  - `file_exists()` method in SpacesUploader
+
+- **Skip reason tracking**: See why timestamps are excluded from processing
+  - Categories: already_exists, insufficient_sources, processing_failed
+  - Enhanced summary logging with exact skip reasons
+
+- **Shared utility modules** for code deduplication:
+  - `timestamps.py`: Timestamp generation, normalization, cache checking
+  - `hdf5_utils.py`: Common HDF5 processing functions
+  - `parallel_download.py`: Parallel download execution
+
+### Changed
+- **Refactored all 6 source implementations** to use cache-aware pattern
+  - New `get_available_timestamps()` method (query without download)
+  - New `download_timestamps()` method (download specific timestamps)
+  - ARSO special handling (only provides latest timestamp)
+  - ~150 lines of duplicate code removed
+
+### Documentation
+- Added cache-aware downloading mermaid diagrams
+- Documented all 6 sources with correct specifications
+- Added cache troubleshooting guide
+- Added S3 composite existence check documentation
+
 ## [2.2.1] - 2026-01-28
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,12 +12,21 @@ flowchart TB
         DWD["DWD<br/>Germany"]
         SHMU["SHMU<br/>Slovakia"]
         CHMI["CHMI<br/>Czech Republic"]
+        OMSZ["OMSZ<br/>Hungary"]
+        ARSO["ARSO<br/>Slovenia"]
+        IMGW["IMGW<br/>Poland"]
+    end
+
+    subgraph cache["PROCESSED CACHE"]
+        C1["Check cached timestamps"]
+        C2["Skip if in cache"]
+        C3["Download only new"]
     end
 
     subgraph download["DOWNLOAD"]
         D1["Parallel download (6 workers)"]
         D2["Temp files in system directory"]
-        D3["Session caching"]
+        D3["Cache downloaded data"]
     end
 
     subgraph process["PROCESS (HDF5 → NumPy)"]
@@ -26,7 +35,8 @@ flowchart TB
         P3["NaN handling for nodata/undetect"]
     end
 
-    sources --> download
+    sources --> cache
+    cache --> download
     download --> process
 
     process --> SINGLE["SINGLE SOURCE<br/>(fetch command)"]
@@ -103,6 +113,222 @@ flowchart TB
 | **Coverage** | 12°-19°E, 48.5°-51.1°N |
 
 **Implementation**: `src/imeteo_radar/sources/chmi.py`
+
+### OMSZ (Hungarian Meteorological Service)
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | https://odp.met.hu/weather/radar/composite/nc |
+| **Product** | cmax (refl2D - column maximum reflectivity) |
+| **Format** | netCDF (zipped) |
+| **Projection** | Geographic (lat/lon grid) |
+| **Grid size** | 813 × 961 pixels |
+| **Resolution** | ~890 m × 930 m |
+| **Coverage** | 13.5°-25.5°E, 44.0°-50.5°N |
+
+**Implementation**: `src/imeteo_radar/sources/omsz.py`
+
+### ARSO (Slovenian Environment Agency)
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | https://meteo.arso.gov.si/uploads/probase/www/observ/radar |
+| **Product** | zm (si0-zm.srd - maximum reflectivity) |
+| **Format** | SRD-3 (proprietary ASCII + byte-encoded) |
+| **Projection** | Lambert Conformal Conic (SIRAD) |
+| **Grid size** | 401 × 301 pixels |
+| **Resolution** | 1 km |
+| **Coverage** | ~12.8°-16.8°E, ~45.3°-47.1°N |
+
+**Note**: ARSO only provides the latest timestamp (no archive).
+
+**Implementation**: `src/imeteo_radar/sources/arso.py`
+
+### IMGW (Polish Institute of Meteorology and Water Management)
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | https://danepubliczne.imgw.pl/pl/datastore/getfiledown/Oper/Polrad/Produkty/HVD |
+| **Product** | cmax (COMPO_CMAX_250 - column maximum reflectivity) |
+| **Format** | ODIM_H5 |
+| **Projection** | Geographic (lat/lon from HDF5 corners) |
+| **Grid size** | Variable (from HDF5 metadata) |
+| **Resolution** | Variable (from HDF5 metadata) |
+| **Coverage** | 13.0°-26.4°E, 48.1°-56.2°N |
+
+**Implementation**: `src/imeteo_radar/sources/imgw.py`
+
+---
+
+## Cache-Aware Downloading
+
+The composite command uses intelligent caching to minimize redundant downloads and network usage.
+
+### How It Works
+
+```mermaid
+flowchart TB
+    subgraph query["1. QUERY PROVIDER"]
+        Q1["get_available_timestamps()"]
+        Q2["Returns: [ts1, ts2, ts3, ...]"]
+    end
+
+    subgraph check["2. CHECK CACHE"]
+        C1["Load cached timestamps"]
+        C2["Compare with available"]
+        C3["Identify new timestamps"]
+    end
+
+    subgraph decide["3. DOWNLOAD DECISION"]
+        D1{{"New timestamps?"}}
+        D2["download_timestamps()"]
+        D3["Use cached data"]
+    end
+
+    subgraph cache["4. CACHE RESULT"]
+        CA1["Save processed data as .npz"]
+        CA2["Update cache index"]
+    end
+
+    query --> check
+    check --> decide
+    D1 -->|Yes| D2
+    D1 -->|No| D3
+    D2 --> cache
+    D3 --> process["Continue to processing"]
+    cache --> process
+```
+
+### Cache Structure
+
+Processed radar data is cached as NumPy compressed files (`.npz`):
+
+```
+~/.cache/imeteo-radar/
+├── dwd_dmax_202601281430.npz
+├── shmu_zmax_202601281430.npz
+├── chmi_maxz_202601281435.npz
+├── omsz_cmax_202601281430.npz
+├── arso_zm_202601281430.npz
+└── imgw_cmax_202601281425.npz
+```
+
+Each `.npz` file contains:
+- `data`: Processed reflectivity array (float32)
+- `extent`: Geographic bounds [west, east, south, north]
+- `projection`: Source projection string
+- `timestamp`: Original timestamp
+
+### Timestamp Normalization
+
+Different sources use different timestamp formats:
+
+| Source | Format | Example |
+|--------|--------|---------|
+| DWD | `YYYYMMDD_HHMM` | `20260128_1430` |
+| SHMU | `YYYYMMDDHHMM` | `202601281430` |
+| CHMI | `YYYYMMDDHHMMSS` | `20260128143500` |
+| Cache | `YYYYMMDDHHMM00` | `202601281430` (normalized) |
+
+The `is_timestamp_in_cache()` utility handles normalization:
+
+```python
+def is_timestamp_in_cache(timestamp: str, cached_set: set[str]) -> bool:
+    """Check if timestamp matches any cache entry."""
+    ts_clean = timestamp.replace("_", "")
+    ts_12 = ts_clean[:12]
+    ts_14 = ts_12 + "00"
+    return any(t in cached_set for t in [timestamp, ts_clean, ts_12, ts_14])
+```
+
+### Efficiency Gains
+
+| Metric | Without Cache | With Cache |
+|--------|---------------|------------|
+| Downloads per run | ~48 files | ~6 files |
+| Network usage | ~50 MB | ~6 MB |
+| Run time | ~30 sec | ~10 sec |
+
+---
+
+## Data Freshness
+
+The system tracks data freshness to detect outages and stale sources.
+
+### Freshness Flow
+
+```mermaid
+flowchart LR
+    subgraph sources["SOURCE DATA"]
+        S1["DWD: 14:30"]
+        S2["SHMU: 14:30"]
+        S3["CHMI: 14:35"]
+        S4["OMSZ: 14:30"]
+        S5["ARSO: 14:30"]
+        S6["IMGW: 14:25"]
+    end
+
+    subgraph freshness["FRESHNESS CHECK"]
+        F1["Current time: 14:38"]
+        F2["Calculate age"]
+        F3{{"Age < 30 min?"}}
+    end
+
+    subgraph status["SOURCE STATUS"]
+        ST1["✅ AVAILABLE"]
+        ST2["⚠️ STALE"]
+        ST3["❌ MISSING"]
+    end
+
+    sources --> freshness
+    F3 -->|Yes| ST1
+    F3 -->|No, but data exists| ST2
+    F3 -->|No data| ST3
+```
+
+### Composite Skip Reasons
+
+When a timestamp is not processed, one of three reasons applies:
+
+| Reason | Description | Log |
+|--------|-------------|-----|
+| `already_exists` | Composite PNG already generated | `Already exist (local/S3): 5` |
+| `insufficient_sources` | Less than 3 core sources available | `Insufficient sources: 1` |
+| `processing_failed` | Error during merge/export | `Processing failed: 0` |
+
+### Outage Detection
+
+The system detects source outages using:
+
+1. **Staleness threshold**: Data older than 30 minutes
+2. **Minimum sources**: At least 3/5 core sources required
+3. **Consecutive failures**: Tracked for alerting
+
+```mermaid
+flowchart TB
+    subgraph detect["OUTAGE DETECTION"]
+        D1["Check newest timestamp age"]
+        D2{{"Age > 30 min?"}}
+        D3["Mark as STALE"]
+        D4["Mark as AVAILABLE"]
+    end
+
+    subgraph count["SOURCE COUNT"]
+        C1["Count available sources"]
+        C2{{"Available >= 3?"}}
+        C3["❌ Skip composite"]
+        C4["✅ Generate composite"]
+    end
+
+    D1 --> D2
+    D2 -->|Yes| D3
+    D2 -->|No| D4
+    D3 --> count
+    D4 --> count
+    C1 --> C2
+    C2 -->|No| C3
+    C2 -->|Yes| C4
+```
 
 ---
 
@@ -269,10 +495,13 @@ graph LR
         CLIC[cli_composite.py<br/>Composite command]
 
         subgraph sources/
-            BASE1[base.py]
+            BASE1[base.py<br/>Base class]
             DWD_S[dwd.py]
             SHMU_S[shmu.py]
             CHMI_S[chmi.py]
+            OMSZ_S[omsz.py]
+            ARSO_S[arso.py]
+            IMGW_S[imgw.py]
         end
 
         subgraph processing/
@@ -288,13 +517,21 @@ graph LR
         subgraph config/
             CMAP[shmu_colormap.py<br/>SHMU colorscale]
         end
+
+        subgraph utils/
+            TS[timestamps.py<br/>Timestamp handling]
+            CACHE[processed_cache.py<br/>Cache management]
+            PARA[parallel_download.py<br/>Parallel downloads]
+        end
     end
 
     CLI --> sources/
     CLI --> processing/
     CLIC --> processing/
+    CLIC --> utils/
     processing/ --> core/
     processing/ --> config/
+    sources/ --> utils/
 ```
 
 ---
@@ -304,8 +541,17 @@ graph LR
 ### Download
 
 - **Workers**: 6 concurrent
-- **Session caching**: Prevents re-downloads
+- **Processed data cache**: Skip downloads for cached timestamps
 - **Timeout**: 30 seconds per file
+- **Cache format**: NumPy compressed (`.npz`)
+
+### Cache Efficiency
+
+| Scenario | Downloads | Savings |
+|----------|-----------|---------|
+| Cold cache (first run) | 8 files × 6 sources | 0% |
+| Warm cache (steady state) | 1 file × 6 sources | ~87% |
+| Full cache hit (no updates) | 0 files | 100% |
 
 ### Processing
 
@@ -318,6 +564,14 @@ graph LR
 - **Method**: PIL with pre-computed LUT
 - **Compression**: Maximum PNG level 9
 - **Speed**: 4-10x faster than matplotlib
+
+### Typical Run Times
+
+| Operation | Cold Cache | Warm Cache |
+|-----------|------------|------------|
+| Composite (6 sources) | ~30 sec | ~10 sec |
+| Single fetch | ~5 sec | ~2 sec |
+| Cache lookup | - | <100 ms |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.2.1"
+version = "2.3.0"
 description = "Weather radar data processor for DWD, SHMU, CHMI, ARSO, and OMSZ weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -7,11 +7,167 @@ Separated into its own module to keep cli.py manageable.
 
 import gc
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from .core.logging import get_logger
+from .utils.spaces_uploader import SpacesUploader, is_spaces_configured
+from .utils.timestamps import is_timestamp_in_cache, normalize_timestamp
 
 logger = get_logger(__name__)
+
+# Fixed reference extent covering all sources (DWD, SHMU, CHMI, OMSZ, ARSO, IMGW)
+# Using this ensures consistent composite dimensions regardless of which sources are available
+# Calculated from the union of all source extents
+REFERENCE_EXTENT = {
+    "west": 2.50,   # DWD westernmost
+    "east": 26.40,  # IMGW easternmost
+    "south": 44.00, # OMSZ southernmost
+    "north": 56.20, # IMGW northernmost
+}
+
+# Source classification for outage detection
+# Core sources are required for good geographic coverage
+CORE_SOURCES = {"dwd", "shmu", "chmi", "omsz", "imgw"}
+# Optional sources are nice to have but not required
+OPTIONAL_SOURCES = {"arso"}
+
+# Default thresholds for outage detection
+DEFAULT_MIN_CORE_SOURCES = 3  # Allow up to 2 core source outages
+DEFAULT_MAX_DATA_AGE_MINUTES = 30  # Data older than this is considered stale
+DEFAULT_REPROCESS_COUNT = 6  # Process last 30 minutes (6 × 5 min intervals)
+
+
+def _detect_source_outages(
+    sources: dict,
+    all_source_files: dict,
+    max_data_age_minutes: int = DEFAULT_MAX_DATA_AGE_MINUTES,
+) -> tuple[dict[str, bool], dict[str, str]]:
+    """Detect which sources are in OUTAGE state.
+
+    A source is considered in OUTAGE if:
+    1. No data available - download fails or returns empty
+    2. Stale data - newest timestamp is older than max_data_age_minutes
+
+    Args:
+        sources: Dict of source configurations {name: (source_obj, product)}
+        all_source_files: Dict of downloaded files {name: [file_info, ...]}
+        max_data_age_minutes: Maximum age of data in minutes (default: 30)
+
+    Returns:
+        Tuple of:
+        - availability: Dict[str, bool] - source_name -> is_available (True) or in_outage (False)
+        - reasons: Dict[str, str] - source_name -> reason for outage (if any)
+    """
+    from datetime import datetime, timedelta
+
+    import pytz
+
+    availability = {}
+    reasons = {}
+    now = datetime.now(pytz.UTC)
+    max_age = timedelta(minutes=max_data_age_minutes)
+
+    logger.info("Checking source availability...")
+
+    for source_name in sources.keys():
+        files = all_source_files.get(source_name, [])
+
+        if not files:
+            # No data available - OUTAGE
+            availability[source_name] = False
+            reasons[source_name] = "no data available"
+            logger.warning(
+                f"  {source_name.upper()}: OUTAGE (no data available)",
+                extra={"source": source_name, "status": "outage"},
+            )
+            continue
+
+        # Find newest timestamp
+        newest_ts = None
+        newest_dt = None
+
+        for file_info in files:
+            ts_str = file_info.get("timestamp", "")
+            if not ts_str:
+                continue
+
+            try:
+                # Parse timestamp (format: YYYYMMDDHHMMSS or YYYYMMDDHHMM)
+                dt = datetime.strptime(ts_str[:12], "%Y%m%d%H%M")
+                dt = pytz.UTC.localize(dt)
+
+                if newest_dt is None or dt > newest_dt:
+                    newest_dt = dt
+                    newest_ts = ts_str
+            except ValueError:
+                continue
+
+        if newest_dt is None:
+            # No valid timestamps - OUTAGE
+            availability[source_name] = False
+            reasons[source_name] = "no valid timestamps"
+            logger.warning(
+                f"  {source_name.upper()}: OUTAGE (no valid timestamps)",
+                extra={"source": source_name, "status": "outage"},
+            )
+            continue
+
+        # Check data age
+        data_age = now - newest_dt
+        age_minutes = int(data_age.total_seconds() / 60)
+
+        if data_age > max_age:
+            # Stale data - OUTAGE
+            availability[source_name] = False
+            reasons[source_name] = f"stale data (age: {age_minutes} min, max: {max_data_age_minutes} min)"
+            logger.warning(
+                f"  {source_name.upper()}: OUTAGE (stale data, age: {age_minutes} min)",
+                extra={"source": source_name, "status": "outage", "age_min": age_minutes},
+            )
+        else:
+            # Available
+            availability[source_name] = True
+            logger.info(
+                f"  {source_name.upper()}: AVAILABLE (newest: {newest_ts}, age: {age_minutes} min)",
+                extra={"source": source_name, "status": "available", "timestamp": newest_ts, "age_min": age_minutes},
+            )
+
+    return availability, reasons
+
+
+def _count_available_core_sources(availability: dict[str, bool]) -> tuple[int, int]:
+    """Count available core sources.
+
+    Args:
+        availability: Dict of source_name -> is_available
+
+    Returns:
+        Tuple of (available_core_count, total_core_count)
+    """
+    available_core = sum(
+        1 for src in CORE_SOURCES if src in availability and availability[src]
+    )
+    total_core = sum(1 for src in CORE_SOURCES if src in availability)
+    return available_core, total_core
+
+
+def _filter_available_sources(
+    sources: dict, availability: dict[str, bool]
+) -> dict:
+    """Filter sources to only include available ones.
+
+    Args:
+        sources: Dict of source configurations
+        availability: Dict of source_name -> is_available
+
+    Returns:
+        Filtered sources dict with only available sources
+    """
+    return {
+        name: config
+        for name, config in sources.items()
+        if availability.get(name, False)
+    }
 
 
 def composite_command_impl(args: Any) -> int:
@@ -27,12 +183,36 @@ def composite_command_impl(args: Any) -> int:
 
         # Parse sources list
         source_names = [s.strip() for s in args.sources.split(",")]
-        logger.info(f"Creating composite from sources: {', '.join(source_names).upper()}")
+        logger.info(
+            f"Creating composite from sources: {', '.join(source_names).upper()}"
+        )
 
         # Create output directory
         output_dir = args.output
         output_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Output directory: {output_dir}")
+
+        # Initialize DigitalOcean Spaces uploader
+        uploader = None
+        upload_enabled = not getattr(args, "disable_upload", False)
+
+        if upload_enabled:
+            if is_spaces_configured():
+                try:
+                    uploader = SpacesUploader()
+                    logger.info("DigitalOcean Spaces upload enabled")
+                except Exception as e:
+                    logger.warning(f"Failed to initialize Spaces uploader: {e}")
+                    logger.warning("Falling back to local-only mode (upload disabled)")
+                    upload_enabled = False
+            else:
+                logger.warning(
+                    "DigitalOcean Spaces not configured (missing environment variables)"
+                )
+                logger.warning("Falling back to local-only mode (upload disabled)")
+                upload_enabled = False
+        else:
+            logger.info("Local-only mode (--disable-upload flag used)")
 
         # Initialize sources
         sources = {}
@@ -59,10 +239,10 @@ def composite_command_impl(args: Any) -> int:
         # Determine what to process
         if args.backload:
             # Backload mode - process historical data
-            return _process_backload(args, sources, exporter, output_dir)
+            return _process_backload(args, sources, exporter, output_dir, uploader)
         else:
             # Single timestamp mode - process latest available data
-            return _process_latest(args, sources, exporter, output_dir)
+            return _process_latest(args, sources, exporter, output_dir, uploader)
 
     except KeyboardInterrupt:
         logger.warning("Interrupted by user")
@@ -76,19 +256,25 @@ def composite_command_impl(args: Any) -> int:
 
 
 def _find_common_timestamp_with_tolerance(
-    timestamp_groups, sources, tolerance_minutes=2
+    timestamp_groups, sources, tolerance_minutes=2, min_sources=None
 ):
-    """Find most recent timestamp where all sources have data within tolerance window
+    """Find most recent timestamp where sources have data within tolerance window
 
     Args:
         timestamp_groups: Dict mapping timestamp str -> Dict[source_name, file_info]
         sources: Dict of source configurations
         tolerance_minutes: Maximum time difference allowed (default: 2 minutes)
+        min_sources: Minimum sources required (default: all sources).
+                     Set lower for resilience to source outages.
 
     Returns:
         (common_timestamp, source_files) or (None, None)
     """
     from datetime import datetime, timedelta
+
+    # Default to requiring all sources
+    if min_sources is None:
+        min_sources = len(sources)
 
     # Parse all timestamps to datetime
     timestamp_datetimes = {}
@@ -106,7 +292,11 @@ def _find_common_timestamp_with_tolerance(
 
     tolerance = timedelta(minutes=tolerance_minutes)
 
-    # For each timestamp, check if all sources have data within tolerance
+    # Track best partial match for resilience
+    best_partial_match = None
+    best_partial_count = 0
+
+    # For each timestamp, check if sources have data within tolerance
     for candidate_ts in sorted_timestamps:
         candidate_dt = timestamp_datetimes[candidate_ts]
         sources_in_window = {}
@@ -125,7 +315,7 @@ def _find_common_timestamp_with_tolerance(
                         if abs(ts_dt - candidate_dt) < abs(existing_dt - candidate_dt):
                             sources_in_window[source_name] = (ts_str, file_info, ts_dt)
 
-        # Check if all sources present
+        # Check if we have enough sources (all or minimum required)
         if len(sources_in_window) == len(sources):
             logger.info(f"Found common time window around {candidate_ts}")
             for src, (ts, _, dt) in sources_in_window.items():
@@ -136,18 +326,132 @@ def _find_common_timestamp_with_tolerance(
                 src: info for src, (_, info, _) in sources_in_window.items()
             }
 
+        # Track best partial match if we allow partial composites
+        if min_sources < len(sources) and len(sources_in_window) >= min_sources:
+            if len(sources_in_window) > best_partial_count:
+                best_partial_count = len(sources_in_window)
+                best_partial_match = (candidate_ts, sources_in_window)
+
+    # Return best partial match if no full match found and partial allowed
+    if best_partial_match and best_partial_count >= min_sources:
+        candidate_ts, sources_in_window = best_partial_match
+        missing = set(sources.keys()) - set(sources_in_window.keys())
+        logger.warning(
+            f"No full match found. Using partial composite with {best_partial_count}/{len(sources)} sources"
+        )
+        logger.warning(f"   Missing sources: {', '.join(s.upper() for s in missing)}")
+        logger.info(f"Found partial time window around {candidate_ts}")
+        for src, (ts, _, dt) in sources_in_window.items():
+            candidate_dt = timestamp_datetimes[candidate_ts]
+            offset = (dt - candidate_dt).total_seconds() / 60
+            logger.debug(f"   {src.upper()}: {ts} (offset: {offset:+.1f} min)")
+
+        return candidate_ts, {
+            src: info for src, (_, info, _) in sources_in_window.items()
+        }
+
     return None, None
 
 
-def _process_latest(args, sources, exporter, output_dir):
-    """Process latest available data from all sources - MEMORY OPTIMIZED TWO-PASS VERSION
+def _find_multiple_common_timestamps(
+    timestamp_groups: dict,
+    sources: dict,
+    tolerance_minutes: int = 2,
+    min_sources: int = None,
+    max_count: int = 6,
+) -> list[tuple[str, dict]]:
+    """Find multiple recent timestamps where sources have data within tolerance window.
+
+    Args:
+        timestamp_groups: Dict mapping timestamp str -> Dict[source_name, file_info]
+        sources: Dict of source configurations
+        tolerance_minutes: Maximum time difference allowed (default: 2 minutes)
+        min_sources: Minimum sources required (default: all sources)
+        max_count: Maximum number of timestamps to return (default: 6)
+
+    Returns:
+        List of (timestamp, source_files) tuples, most recent first
+    """
+    from datetime import datetime, timedelta
+
+    if min_sources is None:
+        min_sources = len(sources)
+
+    # Parse all timestamps to datetime
+    timestamp_datetimes = {}
+    for ts_str in timestamp_groups.keys():
+        try:
+            dt = datetime.strptime(ts_str[:12], "%Y%m%d%H%M")
+            timestamp_datetimes[ts_str] = dt
+        except ValueError:
+            continue
+
+    # Sort by datetime (most recent first)
+    sorted_timestamps = sorted(
+        timestamp_datetimes.keys(), key=lambda x: timestamp_datetimes[x], reverse=True
+    )
+
+    tolerance = timedelta(minutes=tolerance_minutes)
+    results = []
+    processed_windows = set()  # Track which time windows we've already matched
+
+    for candidate_ts in sorted_timestamps:
+        if len(results) >= max_count:
+            break
+
+        candidate_dt = timestamp_datetimes[candidate_ts]
+
+        # Skip if we already have a result within this time window
+        window_key = candidate_dt.strftime("%Y%m%d%H%M")
+        if window_key in processed_windows:
+            continue
+
+        sources_in_window = {}
+
+        # Find sources with data in this time window
+        for ts_str, ts_dt in timestamp_datetimes.items():
+            if abs(ts_dt - candidate_dt) <= tolerance:
+                for source_name, file_info in timestamp_groups[ts_str].items():
+                    if source_name not in sources_in_window:
+                        sources_in_window[source_name] = (ts_str, file_info, ts_dt)
+                    else:
+                        # Keep the closer timestamp
+                        existing_ts, existing_info, existing_dt = sources_in_window[source_name]
+                        if abs(ts_dt - candidate_dt) < abs(existing_dt - candidate_dt):
+                            sources_in_window[source_name] = (ts_str, file_info, ts_dt)
+
+        # Check if we have enough sources
+        if len(sources_in_window) >= min_sources:
+            processed_windows.add(window_key)
+            source_files = {src: info for src, (_, info, _) in sources_in_window.items()}
+            results.append((candidate_ts, source_files))
+            logger.debug(
+                f"Found common timestamp {candidate_ts} with {len(source_files)} sources"
+            )
+
+    return results
+
+
+def _process_latest(args, sources, exporter, output_dir, uploader=None):
+    """Process latest available data from all sources with outage detection and reprocessing.
+
+    OUTAGE DETECTION:
+    - Detects sources that are unavailable or have stale data (>max_data_age)
+    - Filters to available sources only
+    - Validates minimum core sources requirement before proceeding
+
+    MULTI-TIMESTAMP REPROCESSING:
+    - Processes up to reprocess_count recent timestamps (default: 6 = 30 min)
+    - Allows automatic reprocessing when providers backload data after outages
+    - Skips timestamps where composite already exists (unless sources changed)
 
     TWO-PASS ARCHITECTURE for ~75% memory reduction:
     - Pass 1: Extract extents only (no data loading) -> Calculate combined extent
     - Pass 2: Process each source sequentially: Load -> Export individual -> Merge -> Delete
 
-    Ensures all sources have data for the SAME timestamp before creating composite.
-    Also exports individual source images with their native extents.
+    CACHE INTEGRATION:
+    - Caches processed radar data to bridge timestamp gaps between fast/slow sources
+    - ARSO (~7-8 min latency) data is cached so it can be matched with slower sources
     """
     from datetime import datetime
 
@@ -155,229 +459,553 @@ def _process_latest(args, sources, exporter, output_dir):
 
     from .processing.compositor import RadarCompositor
 
-    logger.info("Finding common timestamp across all sources...")
-
-    # Step 1: Download recent timestamps from each source (get more to find overlap)
-    all_source_files = {}
-    for source_name, (source, product) in sources.items():
-        logger.info(f"Checking {source_name.upper()} recent timestamps...")
-        files = source.download_latest(
-            count=4, products=[product]
-        )  # Get last 4 to find overlap (reduced from 10 to save memory)
-
-        if files:
-            all_source_files[source_name] = files
-            timestamps = [f["timestamp"] for f in files[:3]]  # Show first 3
-            logger.info(
-                f"Found {len(files)} timestamps (recent: {', '.join(timestamps)}...)",
-                extra={"source": source_name, "count": len(files)},
-            )
-        else:
-            logger.error(f"No data from {source_name.upper()}")
-            return 1
-
-    # Step 2: Find most recent timestamp that ALL sources have
-    logger.info("Finding common timestamp...")
-
-    # Group files by timestamp
-    timestamp_groups = {}
-    for source_name, files in all_source_files.items():
-        for file_info in files:
-            timestamp = file_info["timestamp"]
-            if timestamp not in timestamp_groups:
-                timestamp_groups[timestamp] = {}
-            timestamp_groups[timestamp][source_name] = file_info
-
-    # Find most recent timestamp with all sources (with time-window tolerance)
+    # Get configuration from args
+    max_data_age = getattr(args, "max_data_age", DEFAULT_MAX_DATA_AGE_MINUTES)
+    min_core_sources = getattr(args, "min_core_sources", DEFAULT_MIN_CORE_SOURCES)
+    reprocess_count = getattr(args, "reprocess_count", DEFAULT_REPROCESS_COUNT)
     tolerance = getattr(args, "timestamp_tolerance", 2)
-    common_timestamp, source_files = _find_common_timestamp_with_tolerance(
-        timestamp_groups, sources, tolerance
-    )
 
-    if not common_timestamp:
-        # If ARSO is included and no match found, try again without ARSO
-        # ARSO only provides latest data, so timing mismatches are common
-        require_arso = getattr(args, "require_arso", False)
-        if "arso" in sources and len(sources) > 2 and not require_arso:
-            logger.warning("No common timestamp with ARSO, retrying without ARSO...")
-            logger.info("   (ARSO only provides single latest timestamp)")
+    # Initialize processed data cache
+    cache = None
+    if not getattr(args, "no_cache", False):
+        from .utils.processed_cache import ProcessedDataCache
 
-            # Remove ARSO from sources and timestamp groups
-            del sources["arso"]
-            if "arso" in all_source_files:
-                del all_source_files["arso"]
+        s3_enabled = not getattr(args, "no_cache_upload", False)
+        cache = ProcessedDataCache(
+            local_dir=getattr(args, "cache_dir", Path("/tmp/iradar-data")),
+            ttl_minutes=getattr(args, "cache_ttl", 60),
+            s3_enabled=s3_enabled,
+        )
 
-            # Rebuild timestamp groups without ARSO
-            timestamp_groups = {}
-            for source_name, files in all_source_files.items():
-                for file_info in files:
+        if getattr(args, "clear_cache", False):
+            cleared = cache.clear()
+            logger.info(f"Cleared {cleared} cache entries")
+
+        # Cleanup expired entries on startup
+        cache.cleanup_expired()
+
+    # ========== STEP 1: DOWNLOAD DATA FROM ALL SOURCES ==========
+    logger.info("Downloading data from all sources...")
+    timestamp_groups = {}
+    all_source_files = {}
+    sources_with_cache = set()
+
+    # Check cache first for available timestamps
+    # This is especially important for ARSO which only provides latest data (no archive)
+    # The cache serves as ARSO's "archive" for reprocessing
+    if cache:
+        logger.info("Checking cache for available timestamps...")
+        for source_name in sources.keys():
+            source, product = sources[source_name]
+            cached_timestamps = cache.get_available_timestamps(source_name, product)
+            if cached_timestamps:
+                sources_with_cache.add(source_name)
+                # Log ARSO cache specially since it's critical for reprocessing
+                if source_name == "arso":
+                    logger.info(
+                        f"  ARSO cache: {len(cached_timestamps)} timestamps available "
+                        f"(newest: {cached_timestamps[0] if cached_timestamps else 'none'})"
+                    )
+                else:
+                    logger.debug(
+                        f"  {source_name.upper()} cache: {len(cached_timestamps)} timestamps"
+                    )
+                for ts in cached_timestamps:
+                    ts_normalized = ts[:12] + "00" if len(ts) == 12 else ts
+                    if ts_normalized not in timestamp_groups:
+                        timestamp_groups[ts_normalized] = {}
+                    if source_name not in timestamp_groups[ts_normalized]:
+                        timestamp_groups[ts_normalized][source_name] = {
+                            "timestamp": ts_normalized,
+                            "from_cache": True,
+                            "product": product,
+                        }
+        if not sources_with_cache:
+            logger.info("  No cached data found (first run or cache cleared)")
+
+    # Download fresh data from each source, SKIPPING cached timestamps
+    for source_name, (source, product) in sources.items():
+        # Get cached timestamps for this source
+        cached_ts_set = set()
+        if cache:
+            cached_ts_set = set(cache.get_available_timestamps(source_name, product))
+
+        # Get available timestamps from provider (without downloading yet)
+        available_timestamps = source.get_available_timestamps(
+            count=reprocess_count + 2,
+            products=[product],
+        )
+
+        if not available_timestamps:
+            logger.warning(f"{source_name.upper()}: No timestamps available from provider")
+            all_source_files[source_name] = []
+            continue
+
+        # Determine which timestamps need downloading
+        timestamps_to_download = []
+        timestamps_from_cache = []
+
+        for ts in available_timestamps:
+            if is_timestamp_in_cache(ts, cached_ts_set):
+                timestamps_from_cache.append(ts)
+            else:
+                timestamps_to_download.append(ts)
+
+        logger.info(
+            f"{source_name.upper()}: {len(available_timestamps)} available, "
+            f"{len(timestamps_from_cache)} in cache, "
+            f"{len(timestamps_to_download)} to download"
+        )
+
+        # Download only non-cached timestamps
+        downloaded_files = []
+        if timestamps_to_download:
+            downloaded_files = source.download_timestamps(
+                timestamps=timestamps_to_download,
+                products=[product],
+            )
+            if downloaded_files:
+                for file_info in downloaded_files:
                     timestamp = file_info["timestamp"]
                     if timestamp not in timestamp_groups:
                         timestamp_groups[timestamp] = {}
                     timestamp_groups[timestamp][source_name] = file_info
 
-            # Try matching again
-            common_timestamp, source_files = _find_common_timestamp_with_tolerance(
-                timestamp_groups, sources, tolerance
-            )
+                    # Cache downloaded data immediately (so next run won't re-download)
+                    if cache and file_info.get("path"):
+                        try:
+                            radar_data = source.process_to_array(file_info["path"])
+                            cache.put(source_name, timestamp, product, radar_data)
+                            # Mark for Pass 2 to retrieve from cache, but track as downloaded for stats
+                            file_info["from_cache"] = True
+                            file_info["was_downloaded"] = True  # Track for logging
+                            del radar_data
+                            gc.collect()
+                        except Exception as e:
+                            logger.debug(f"Could not cache {source_name} {timestamp}: {e}")
 
-            if not common_timestamp:
-                logger.error("No common timestamp found even without ARSO")
-                logger.info(f"   Timestamp tolerance: {tolerance} minutes")
-                logger.info(
-                    "Try again in a few minutes or increase --timestamp-tolerance"
-                )
-                return 1
-        else:
-            logger.error("No common timestamp found across all sources")
-            logger.info(f"   Timestamp tolerance: {tolerance} minutes")
-            logger.info("Available timestamps by source:")
-            for source_name in sources.keys():
-                if source_name in all_source_files and all_source_files[source_name]:
-                    timestamps = [
-                        f["timestamp"] for f in all_source_files[source_name][:3]
-                    ]
-                    logger.info(f"   {source_name.upper()}: {', '.join(timestamps)}")
-            logger.info("Try again in a few minutes or increase --timestamp-tolerance")
-            return 1
-
-    # Parse timestamp for filename generation
-    dt = datetime.strptime(common_timestamp[:14], "%Y%m%d%H%M%S")
-    dt_utc = pytz.UTC.localize(dt)
-    unix_timestamp = int(dt_utc.timestamp())
-
-    # Process data from matched sources
-    if not source_files:
-        logger.error("No source files matched (internal error)")
-        return 1
-
-    # ========== PASS 1: EXTRACT EXTENTS ONLY (NO DATA LOADING) ==========
-    logger.info("Pass 1: Extracting extents only (memory-efficient)...")
-    all_extents = []
-    source_metadata = {}
-
-    for source_name, file_info in source_files.items():
-        source, _product = sources[source_name]
-        try:
-            # Extract extent WITHOUT loading full data array
-            extent_info = source.extract_extent_only(file_info["path"])
-            all_extents.append(extent_info["extent"]["wgs84"])
-            source_metadata[source_name] = {
-                "file_path": file_info["path"],
-                "dimensions": extent_info["dimensions"],
+        # Build cached file info entries for outage detection
+        cached_file_infos = []
+        for ts in timestamps_from_cache:
+            ts_normalized = normalize_timestamp(ts, target_length=14)
+            cached_file_info = {
+                "timestamp": ts_normalized,
+                "from_cache": True,
+                "product": product,
             }
-            logger.debug(f"   {source_name.upper()}: extent extracted")
-        except Exception as e:
-            logger.error(f"Failed to extract extent from {source_name}: {e}")
-            return 1
+            cached_file_infos.append(cached_file_info)
 
-    # Calculate combined extent from all sources
-    combined_extent = {
-        "west": min(ext["west"] for ext in all_extents),
-        "east": max(ext["east"] for ext in all_extents),
-        "south": min(ext["south"] for ext in all_extents),
-        "north": max(ext["north"] for ext in all_extents),
-    }
-    logger.info(
-        f"Combined extent: {combined_extent['west']:.2f}E to {combined_extent['east']:.2f}E, "
-        f"{combined_extent['south']:.2f}N to {combined_extent['north']:.2f}N"
+            # Add to timestamp_groups
+            if ts_normalized not in timestamp_groups:
+                timestamp_groups[ts_normalized] = {}
+            if source_name not in timestamp_groups[ts_normalized]:
+                timestamp_groups[ts_normalized][source_name] = cached_file_info
+
+        # Combine downloaded + cached for all_source_files (used by outage detection)
+        all_source_files[source_name] = downloaded_files + cached_file_infos
+
+        if not timestamps_to_download and timestamps_from_cache:
+            logger.debug(f"  {source_name.upper()}: Using cached data, no download needed")
+
+    # Re-add any cached timestamps not already in timestamp_groups
+    if cache:
+        for source_name in sources.keys():
+            source, product = sources[source_name]
+            cached_timestamps = cache.get_available_timestamps(source_name, product)
+            for ts in cached_timestamps:
+                ts_normalized = normalize_timestamp(ts, target_length=14)
+                if ts_normalized not in timestamp_groups:
+                    timestamp_groups[ts_normalized] = {}
+                if source_name not in timestamp_groups[ts_normalized]:
+                    timestamp_groups[ts_normalized][source_name] = {
+                        "timestamp": ts_normalized,
+                        "from_cache": True,
+                        "product": product,
+                    }
+
+    # Log summary of timestamps per source (downloaded + cached)
+    logger.info("Timestamps available for matching (download + cache):")
+    for source_name in sources.keys():
+        source_timestamps = sorted(
+            [ts for ts, srcs in timestamp_groups.items() if source_name in srcs],
+            reverse=True,
+        )
+        if source_timestamps:
+            # Show total count and newest few timestamps
+            recent = source_timestamps[:3]
+            # Count downloads: either not from_cache, or was_downloaded (cached after download this run)
+            download_count = sum(
+                1 for ts in source_timestamps
+                if not timestamp_groups[ts][source_name].get("from_cache", False)
+                or timestamp_groups[ts][source_name].get("was_downloaded", False)
+            )
+            cache_count = len(source_timestamps) - download_count
+            logger.info(
+                f"  {source_name.upper()}: {len(source_timestamps)} timestamps "
+                f"({download_count} downloaded, {cache_count} cached) "
+                f"[recent: {', '.join(recent)}]"
+            )
+        else:
+            logger.info(f"  {source_name.upper()}: 0 timestamps")
+
+    # ========== STEP 2: DETECT SOURCE OUTAGES ==========
+    availability, outage_reasons = _detect_source_outages(
+        sources, all_source_files, max_data_age
     )
 
-    # ========== PASS 2: SEQUENTIAL PROCESSING (ONE SOURCE AT A TIME) ==========
-    logger.info("Pass 2: Processing sources sequentially (memory-optimized)...")
+    # Count available sources
+    available_count = sum(1 for v in availability.values() if v)
+    outage_count = sum(1 for v in availability.values() if not v)
 
-    # Create compositor with pre-computed combined extent
-    compositor = RadarCompositor(combined_extent, resolution_m=args.resolution)
-
-    for source_name in source_files:
-        source, _product = sources[source_name]
-        file_path = source_metadata[source_name]["file_path"]
-
-        try:
-            # Load ONE source at a time
-            logger.info(f"Loading {source_name.upper()}...", extra={"source": source_name})
-            radar_data = source.process_to_array(file_path)
-
-            # Export individual source image if requested
-            if not args.no_individual:
-                _export_single_source(
-                    source_name,
-                    radar_data,
-                    exporter,
-                    unix_timestamp,
-                    common_timestamp,
-                    args,
-                )
-                # Free export-related memory before merging
-                gc.collect()
-
-            # Merge into compositor
-            compositor.add_source(source_name, radar_data)
-
-            # CRITICAL: Release memory immediately after merging
-            del radar_data
-            gc.collect()
-
-            # Delete temp file
-            try:
-                Path(file_path).unlink(missing_ok=True)
-            except Exception:
-                pass
-
-            logger.info(f"{source_name.upper()}: processed and merged")
-
-        except Exception as e:
-            logger.error(f"Failed to process {source_name}: {e}")
-            return 1
-
-    # Get final composite
-    logger.info("Finalizing composite...")
-    composite = compositor.get_composite()
-
-    # Generate output filename
-    filename = f"{unix_timestamp}.png"
-    output_path = output_dir / filename
-
-    # Export composite to PNG
-    logger.info(f"Exporting composite to {filename} (timestamp: {common_timestamp})...")
-    radar_data_for_export = {
-        "data": composite["data"],
-        "timestamp": common_timestamp,
-        "product": "composite",
-        "source": "composite",
-        "units": "dBZ",
-    }
-    exporter.export_png_fast(
-        radar_data=radar_data_for_export,
-        output_path=output_path,
-        extent={"wgs84": composite["extent"]},
-        colormap_type="shmu",
-    )
-
-    logger.info(f"Composite saved to {output_path}")
-    logger.debug(f"   Data timestamp: {common_timestamp} (Unix: {unix_timestamp})")
-
-    # Update extent index if requested
-    if args.update_extent or not (output_dir / "extent_index.json").exists():
-        # Wrap extent for compatibility
-        composite_for_extent = {
-            "extent": {"wgs84": composite["extent"]},
-            "data": composite["data"],
-        }
-        _save_extent_index(
-            output_dir, composite_for_extent, list(sources.keys()), args.resolution
+    if outage_count > 0:
+        outage_sources = [s.upper() for s, v in availability.items() if not v]
+        logger.warning(
+            f"{outage_count} source(s) in OUTAGE: {', '.join(outage_sources)}"
         )
 
-    # Cleanup to free memory
-    compositor.clear_cache()
-    del compositor, composite
-    gc.collect()
+    # ========== STEP 3: CHECK MINIMUM CORE SOURCES REQUIREMENT ==========
+    available_core, total_core = _count_available_core_sources(availability)
+
+    if available_core < min_core_sources:
+        unavailable_core = [
+            s.upper() for s in CORE_SOURCES
+            if s in availability and not availability[s]
+        ]
+        logger.error(
+            f"Only {available_core}/{total_core} core sources available "
+            f"(minimum required: {min_core_sources})"
+        )
+        logger.error(f"Unavailable core sources: {', '.join(unavailable_core)}")
+        for src in unavailable_core:
+            reason = outage_reasons.get(src.lower(), "unknown")
+            logger.error(f"  {src}: {reason}")
+        return 1
+
+    logger.info(
+        f"{available_core}/{total_core} core sources available "
+        f"(minimum: {min_core_sources}), proceeding with composite generation"
+    )
+
+    # ========== STEP 4: FILTER TO AVAILABLE SOURCES ONLY ==========
+    available_sources = _filter_available_sources(sources, availability)
+
+    # Handle ARSO special case (optional source with single timestamp limitation)
+    # ARSO only provides latest data (no archive), so we cache it for future reprocessing
+    # When slower sources catch up, the cached ARSO data can be matched with them
+    require_arso = getattr(args, "require_arso", False)
+    arso_dropped = False
+
+    if "arso" in available_sources and not require_arso:
+        # Cache ARSO data for future timestamp matching
+        # This builds ARSO's "archive" in the cache
+        if cache and "arso" in all_source_files and all_source_files["arso"]:
+            arso_source, arso_product = sources["arso"]
+            for arso_file in all_source_files["arso"]:
+                # Skip entries that are already from cache (no path to process)
+                if arso_file.get("from_cache") or not arso_file.get("path"):
+                    continue
+                try:
+                    arso_data = arso_source.process_to_array(arso_file["path"])
+                    cache.put("arso", arso_file["timestamp"], arso_product, arso_data)
+                    logger.info(
+                        f"Cached ARSO {arso_file['timestamp']} for future reprocessing"
+                    )
+                    del arso_data
+                    gc.collect()
+                except Exception as e:
+                    logger.warning(f"Failed to cache ARSO data: {e}")
+
+    # ========== STEP 5: FIND MULTIPLE COMMON TIMESTAMPS ==========
+    # Calculate minimum sources needed for matching
+    # Use available_core as baseline, but allow fewer if sources were specified explicitly
+    min_sources_for_match = max(min_core_sources, len(available_sources) - 1)
+
+    # First try to find timestamps with all available sources
+    common_timestamps = _find_multiple_common_timestamps(
+        timestamp_groups,
+        available_sources,
+        tolerance,
+        min_sources=len(available_sources),
+        max_count=reprocess_count,
+    )
+
+    # If no full matches and ARSO is included, try without ARSO
+    if not common_timestamps and "arso" in available_sources and len(available_sources) > 2:
+        logger.info("No common timestamps with ARSO, retrying without ARSO...")
+        logger.info("   (ARSO only provides single latest timestamp)")
+
+        # Remove ARSO from available sources
+        available_sources_no_arso = {
+            k: v for k, v in available_sources.items() if k != "arso"
+        }
+        arso_dropped = True
+
+        common_timestamps = _find_multiple_common_timestamps(
+            timestamp_groups,
+            available_sources_no_arso,
+            tolerance,
+            min_sources=min(min_sources_for_match, len(available_sources_no_arso)),
+            max_count=reprocess_count,
+        )
+
+        if common_timestamps:
+            available_sources = available_sources_no_arso
+
+    # If still no matches, try with reduced source requirement
+    if not common_timestamps:
+        common_timestamps = _find_multiple_common_timestamps(
+            timestamp_groups,
+            available_sources,
+            tolerance,
+            min_sources=min_core_sources,
+            max_count=reprocess_count,
+        )
+
+    if not common_timestamps:
+        logger.error("No common timestamps found across available sources")
+        logger.info(f"   Timestamp tolerance: {tolerance} minutes")
+        logger.info("Available timestamps by source:")
+        for source_name in available_sources.keys():
+            if source_name in all_source_files and all_source_files[source_name]:
+                timestamps = [f["timestamp"] for f in all_source_files[source_name][:3]]
+                logger.info(f"   {source_name.upper()}: {', '.join(timestamps)}")
+        logger.info("Try again in a few minutes or increase --timestamp-tolerance")
+        return 1
+
+    logger.info(f"Found {len(common_timestamps)} timestamps to process")
+
+    # ========== STEP 6: PROCESS EACH TIMESTAMP ==========
+    processed_count = 0
+    last_composite = None
+
+    # Track skip reasons for summary
+    skip_reasons = {
+        "already_exists": [],
+        "insufficient_sources": [],
+        "processing_failed": [],
+    }
+
+    for common_timestamp, source_files in common_timestamps:
+        # Parse timestamp for filename generation
+        try:
+            dt = datetime.strptime(common_timestamp[:14], "%Y%m%d%H%M%S")
+        except ValueError:
+            dt = datetime.strptime(common_timestamp[:12], "%Y%m%d%H%M")
+        dt_utc = pytz.UTC.localize(dt)
+        unix_timestamp = int(dt_utc.timestamp())
+        filename = f"{unix_timestamp}.png"
+        output_path = output_dir / filename
+
+        # Check if composite already exists locally or in S3 (skip if unchanged)
+        exists_locally = output_path.exists()
+        exists_in_s3 = False
+        if not exists_locally and uploader:
+            try:
+                exists_in_s3 = uploader.file_exists("composite", filename)
+            except Exception:
+                pass  # S3 check failed, proceed with processing
+
+        if exists_locally or exists_in_s3:
+            skip_reasons["already_exists"].append(common_timestamp)
+            continue
+
+        logger.info(f"Processing timestamp {common_timestamp}...")
+
+        # Filter source_files to only include available sources
+        source_files = {
+            k: v for k, v in source_files.items() if k in available_sources
+        }
+
+        if len(source_files) < min_core_sources:
+            skip_reasons["insufficient_sources"].append(
+                f"{common_timestamp} ({len(source_files)} sources)"
+            )
+            continue
+
+        # ========== PASS 1: EXTRACT EXTENTS ONLY ==========
+        logger.debug("Pass 1: Extracting extents...")
+        source_metadata = {}
+
+        for source_name, file_info in source_files.items():
+            source, product = available_sources[source_name]
+            from_cache = file_info.get("from_cache", False)
+
+            try:
+                if from_cache and cache:
+                    extent = source.get_extent()
+                    source_metadata[source_name] = {
+                        "from_cache": True,
+                        "dimensions": extent.get("grid_size", [0, 0]),
+                    }
+                else:
+                    extent_info = source.extract_extent_only(file_info["path"])
+                    source_metadata[source_name] = {
+                        "file_path": file_info["path"],
+                        "dimensions": extent_info["dimensions"],
+                    }
+            except Exception as e:
+                logger.warning(f"Failed to extract extent from {source_name}: {e}")
+                continue
+
+        if len(source_metadata) < min_core_sources:
+            skip_reasons["insufficient_sources"].append(
+                f"{common_timestamp} ({len(source_metadata)} valid sources)"
+            )
+            continue
+
+        # Always use fixed reference extent for consistent dimensions
+        combined_extent = REFERENCE_EXTENT.copy()
+
+        # ========== PASS 2: SEQUENTIAL PROCESSING ==========
+        logger.debug("Pass 2: Processing sources sequentially...")
+        compositor = RadarCompositor(combined_extent, resolution_m=args.resolution)
+        sources_processed = 0
+
+        for source_name in source_metadata:
+            source, product = available_sources[source_name]
+            file_info = source_files[source_name]
+            from_cache = file_info.get("from_cache", False)
+
+            try:
+                if from_cache and cache:
+                    radar_data = cache.get(source_name, file_info["timestamp"], product)
+                    if radar_data is None:
+                        logger.debug(f"Cache miss for {source_name}, skipping")
+                        continue
+                else:
+                    file_path = source_metadata[source_name]["file_path"]
+                    radar_data = source.process_to_array(file_path)
+
+                    if cache:
+                        cache.put(
+                            source_name,
+                            radar_data.get("timestamp", file_info["timestamp"]),
+                            product,
+                            radar_data,
+                        )
+
+                # Export individual source image if requested
+                if not args.no_individual:
+                    _export_single_source(
+                        source_name,
+                        radar_data,
+                        exporter,
+                        unix_timestamp,
+                        common_timestamp,
+                        args,
+                        uploader,
+                    )
+                    gc.collect()
+
+                # Merge into compositor
+                compositor.add_source(source_name, radar_data)
+                sources_processed += 1
+
+                # Release memory immediately
+                del radar_data
+                gc.collect()
+
+                # Delete temp file if not from cache
+                if not from_cache and "file_path" in source_metadata.get(source_name, {}):
+                    try:
+                        Path(source_metadata[source_name]["file_path"]).unlink(missing_ok=True)
+                    except Exception:
+                        pass
+
+            except Exception as e:
+                logger.warning(f"Failed to process {source_name}: {e}")
+                continue
+
+        if sources_processed < min_core_sources:
+            skip_reasons["processing_failed"].append(
+                f"{common_timestamp} ({sources_processed} sources processed)"
+            )
+            compositor.clear_cache()
+            del compositor
+            gc.collect()
+            continue
+
+        # Get final composite and export
+        try:
+            composite = compositor.get_composite()
+
+            radar_data_for_export = {
+                "data": composite["data"],
+                "timestamp": common_timestamp,
+                "product": "composite",
+                "source": "composite",
+                "units": "dBZ",
+            }
+            exporter.export_png_fast(
+                radar_data=radar_data_for_export,
+                output_path=output_path,
+                extent={"wgs84": composite["extent"]},
+                colormap_type="shmu",
+            )
+
+            logger.info(
+                f"Composite saved: {filename} ({sources_processed} sources)"
+            )
+
+            # Upload composite to DigitalOcean Spaces
+            if uploader:
+                try:
+                    uploader.upload_file(output_path, "composite", filename)
+                    logger.debug(f"Uploaded composite to Spaces: composite/{filename}")
+                except Exception as e:
+                    logger.warning(f"Failed to upload composite: {e}")
+
+            processed_count += 1
+            last_composite = {
+                "extent": {"wgs84": composite["extent"]},
+                "data": composite["data"],
+            }
+
+            compositor.clear_cache()
+            del compositor, composite
+            gc.collect()
+
+        except Exception as e:
+            logger.error(f"Failed to create composite for {common_timestamp}: {e}")
+            import traceback
+            traceback.print_exc()
+
+    # Update extent index if processed any composites
+    if processed_count > 0:
+        if args.update_extent or not (output_dir / "extent_index.json").exists():
+            if last_composite is not None:
+                _save_extent_index(
+                    output_dir, last_composite, list(available_sources.keys()), args.resolution
+                )
+
+    # Log processing summary with skip reasons
+    total_skipped = sum(len(v) for v in skip_reasons.values())
+    logger.info(
+        f"Processed {processed_count} composite(s), skipped {total_skipped}",
+        extra={"count": processed_count, "skipped": total_skipped},
+    )
+
+    if skip_reasons["already_exists"]:
+        logger.info(
+            f"  Already exist (local/S3): {len(skip_reasons['already_exists'])} "
+            f"[{', '.join(skip_reasons['already_exists'][:3])}{'...' if len(skip_reasons['already_exists']) > 3 else ''}]"
+        )
+    if skip_reasons["insufficient_sources"]:
+        logger.warning(
+            f"  Insufficient sources: {len(skip_reasons['insufficient_sources'])} "
+            f"[{', '.join(skip_reasons['insufficient_sources'][:3])}]"
+        )
+    if skip_reasons["processing_failed"]:
+        logger.warning(
+            f"  Processing failed: {len(skip_reasons['processing_failed'])} "
+            f"[{', '.join(skip_reasons['processing_failed'][:3])}]"
+        )
 
     return 0
 
 
 def _export_individual_sources(
-    sources_data, exporter, unix_timestamp, timestamp_str, args
+    sources_data, exporter, unix_timestamp, timestamp_str, args, uploader=None
 ):
     """Export individual source images with their native extents.
 
@@ -387,6 +1015,7 @@ def _export_individual_sources(
     - CHMI -> /tmp/czechia/
     - ARSO -> /tmp/slovenia/
     - OMSZ -> /tmp/hungary/
+    - IMGW -> /tmp/poland/
 
     Args:
         sources_data: List of (source_name, radar_data) tuples
@@ -394,6 +1023,7 @@ def _export_individual_sources(
         unix_timestamp: Unix timestamp for filename
         timestamp_str: Timestamp string for metadata
         args: CLI arguments
+        uploader: Optional SpacesUploader instance for uploading to DO Spaces
     """
     import json
 
@@ -440,6 +1070,14 @@ def _export_individual_sources(
             colormap_type="shmu",
         )
 
+        # Upload individual source to DigitalOcean Spaces
+        if uploader:
+            try:
+                uploader.upload_file(output_path, source_name, filename)
+                logger.debug(f"Uploaded to Spaces: {source_name}/{filename}")
+            except Exception as e:
+                logger.warning(f"Failed to upload {source_name}: {e}")
+
         # Save extent_index.json if it doesn't exist
         extent_file = source_output_dir / "extent_index.json"
         if not extent_file.exists() or args.update_extent:
@@ -457,7 +1095,13 @@ def _export_individual_sources(
 
 
 def _export_single_source(
-    source_name, radar_data, exporter, unix_timestamp, timestamp_str, args
+    source_name,
+    radar_data,
+    exporter,
+    unix_timestamp,
+    timestamp_str,
+    args,
+    uploader=None,
 ):
     """Export a single source image - called during sequential processing.
 
@@ -471,6 +1115,7 @@ def _export_single_source(
         unix_timestamp: Unix timestamp for filename
         timestamp_str: Timestamp string for metadata
         args: CLI arguments
+        uploader: Optional SpacesUploader instance for uploading to DO Spaces
     """
     import json
 
@@ -505,6 +1150,7 @@ def _export_single_source(
     }
 
     # Export to PNG with native extent
+    filename = f"{unix_timestamp}.png"
     logger.debug(f"{source_name.upper()} -> {output_path}")
     exporter.export_png_fast(
         radar_data=radar_data_for_export,
@@ -512,6 +1158,14 @@ def _export_single_source(
         extent=radar_data["extent"],
         colormap_type="shmu",
     )
+
+    # Upload individual source to DigitalOcean Spaces
+    if uploader:
+        try:
+            uploader.upload_file(output_path, source_name, filename)
+            logger.debug(f"Uploaded to Spaces: {source_name}/{filename}")
+        except Exception as e:
+            logger.warning(f"Failed to upload {source_name}: {e}")
 
     # Save extent_index.json if it doesn't exist
     extent_file = output_dir / "extent_index.json"
@@ -528,7 +1182,7 @@ def _export_single_source(
             json.dump(extent_data, f, indent=2)
 
 
-def _process_backload(args, sources, exporter, output_dir):
+def _process_backload(args, sources, exporter, output_dir, uploader=None):
     """Process historical data from all sources - MEMORY OPTIMIZED TWO-PASS VERSION
 
     TWO-PASS ARCHITECTURE for ~75% memory reduction:
@@ -555,14 +1209,18 @@ def _process_backload(args, sources, exporter, output_dir):
 
     # Remove ARSO from sources for backload mode (no historical data available)
     if "arso" in sources:
-        logger.warning("Excluding ARSO from backload mode (no historical data available)")
+        logger.warning(
+            "Excluding ARSO from backload mode (no historical data available)"
+        )
         logger.info("   ARSO only provides latest data")
         del sources["arso"]
 
     # Download data from all sources for the time range
     all_source_files = {}
     for source_name, (source, product) in sources.items():
-        logger.info(f"Downloading {source_name.upper()} data...", extra={"source": source_name})
+        logger.info(
+            f"Downloading {source_name.upper()} data...", extra={"source": source_name}
+        )
         files = source.download_latest(
             count=intervals, products=[product], start_time=start, end_time=end
         )
@@ -600,7 +1258,9 @@ def _process_backload(args, sources, exporter, output_dir):
         # Skip if not all sources have data for this timestamp
         if len(source_files) < len(sources):
             missing = set(sources.keys()) - set(source_files.keys())
-            logger.debug(f"Skipping {timestamp} (missing: {', '.join(missing).upper()})")
+            logger.debug(
+                f"Skipping {timestamp} (missing: {', '.join(missing).upper()})"
+            )
             continue
 
         logger.info(f"Processing {timestamp}...")
@@ -625,17 +1285,16 @@ def _process_backload(args, sources, exporter, output_dir):
                 logger.warning(f"Failed to extract extent from {source_name}: {e}")
                 continue
 
-        if len(all_extents) < 2:
-            logger.warning("Not enough valid extents for composite, skipping")
+        # Get minimum sources required (for resilience)
+        min_sources_required = getattr(args, "min_sources", 2)
+        if len(all_extents) < min_sources_required:
+            logger.warning(
+                f"Not enough valid extents for composite ({len(all_extents)} < {min_sources_required}), skipping"
+            )
             continue
 
-        # Calculate combined extent
-        combined_extent = {
-            "west": min(ext["west"] for ext in all_extents),
-            "east": max(ext["east"] for ext in all_extents),
-            "south": min(ext["south"] for ext in all_extents),
-            "north": max(ext["north"] for ext in all_extents),
-        }
+        # Always use fixed reference extent for consistent dimensions
+        combined_extent = REFERENCE_EXTENT.copy()
 
         # ========== PASS 2: SEQUENTIAL PROCESSING ==========
         logger.debug("   Pass 2: Processing sources sequentially...")
@@ -659,6 +1318,7 @@ def _process_backload(args, sources, exporter, output_dir):
                         unix_timestamp,
                         timestamp,
                         args,
+                        uploader,
                     )
 
                 # Merge into compositor
@@ -707,6 +1367,14 @@ def _process_backload(args, sources, exporter, output_dir):
                 colormap_type="shmu",
             )
 
+            # Upload composite to DigitalOcean Spaces
+            if uploader:
+                try:
+                    uploader.upload_file(output_path, "composite", filename)
+                    logger.debug(f"Uploaded composite to Spaces: composite/{filename}")
+                except Exception as e:
+                    logger.warning(f"Failed to upload composite: {e}")
+
             processed_count += 1
             last_composite = {
                 "extent": {"wgs84": composite["extent"]},
@@ -724,7 +1392,9 @@ def _process_backload(args, sources, exporter, output_dir):
 
             traceback.print_exc()
 
-    logger.info(f"Processed {processed_count} composites", extra={"count": processed_count})
+    logger.info(
+        f"Processed {processed_count} composites", extra={"count": processed_count}
+    )
 
     # Update extent index if requested
     if args.update_extent or processed_count > 0:

--- a/src/imeteo_radar/sources/chmi.py
+++ b/src/imeteo_radar/sources/chmi.py
@@ -6,8 +6,7 @@ Handles downloading and processing of CHMI radar data in ODIM_H5 format.
 """
 
 import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +20,22 @@ from ..core.base import (
     lonlat_to_mercator,
 )
 from ..core.logging import get_logger
+from ..utils.hdf5_utils import (
+    decode_hdf5_attrs,
+    get_quantity_units,
+    get_scaling_params,
+    scale_radar_data,
+)
+from ..utils.parallel_download import (
+    create_download_result,
+    create_error_result,
+    execute_parallel_downloads,
+)
+from ..utils.timestamps import (
+    TimestampFormat,
+    filter_timestamps_by_range,
+    generate_timestamp_candidates,
+)
 
 logger = get_logger(__name__)
 
@@ -63,31 +78,6 @@ class CHMIRadarSource(RadarSource):
             }
         return super().get_product_metadata(product)
 
-    def _generate_timestamps(self, count: int) -> list[str]:
-        """Generate recent timestamps to search for available data"""
-        timestamps = []
-        import pytz
-
-        current_time = datetime.now(pytz.UTC)  # Use UTC time
-
-        # Start from current time and work backwards in 5-minute intervals
-        for minutes_back in range(
-            0, count * 30, 5
-        ):  # Start from now, go back up to count*30 minutes
-            check_time = current_time - timedelta(minutes=minutes_back)
-            # Round down to nearest 5 minutes
-            check_time = check_time.replace(
-                minute=(check_time.minute // 5) * 5, second=0, microsecond=0
-            )
-            timestamp = check_time.strftime("%Y%m%d%H%M%S")
-
-            if timestamp not in timestamps:
-                timestamps.append(timestamp)
-
-            if len(timestamps) >= count * 4:  # Get extra to account for missing data
-                break
-
-        return timestamps
 
     def _check_timestamp_availability(self, timestamp: str, product: str) -> bool:
         """Check if data is available for a specific timestamp and product"""
@@ -98,37 +88,6 @@ class CHMIRadarSource(RadarSource):
         except Exception:
             return False
 
-    def _filter_timestamps_by_range(
-        self, timestamps: list[str], start_time: datetime, end_time: datetime
-    ) -> list[str]:
-        """Filter timestamps to only include those within the specified time range
-
-        Args:
-            timestamps: List of timestamp strings in format YYYYMMDDHHMMSS (14 digits)
-            start_time: Start of time range (timezone-aware datetime)
-            end_time: End of time range (timezone-aware datetime)
-
-        Returns:
-            Filtered list of timestamps within the range
-        """
-        import pytz
-
-        filtered = []
-        for ts in timestamps:
-            try:
-                # Parse CHMI timestamp format: YYYYMMDDHHMMSS (14 digits)
-                ts_dt = datetime.strptime(ts, "%Y%m%d%H%M%S")
-                # Make timezone aware (CHMI uses UTC)
-                ts_dt = pytz.UTC.localize(ts_dt)
-
-                # Check if timestamp is within range
-                if start_time <= ts_dt <= end_time:
-                    filtered.append(ts)
-            except ValueError:
-                # Skip timestamps that can't be parsed
-                continue
-
-        return filtered
 
     def _get_product_url(self, timestamp: str, product: str) -> str:
         """Generate URL for CHMI product
@@ -145,59 +104,89 @@ class CHMIRadarSource(RadarSource):
     def _download_single_file(self, timestamp: str, product: str) -> dict[str, Any]:
         """Download a single radar file (for parallel processing)"""
         if product not in self.product_mapping:
-            return {
-                "error": f"Unknown product: {product}",
-                "timestamp": timestamp,
-                "product": product,
-                "success": False,
-            }
+            return create_error_result(timestamp, product, f"Unknown product: {product}")
 
         try:
-            # Check if we've already downloaded this file in this session
+            # Check session cache
             cache_key = f"{timestamp}_{product}"
             if cache_key in self.temp_files:
-                return {
-                    "timestamp": timestamp,
-                    "product": product,
-                    "path": self.temp_files[cache_key],
-                    "url": self._get_product_url(timestamp, product),
-                    "cached": True,
-                    "success": True,
-                }
+                return create_download_result(
+                    timestamp=timestamp,
+                    product=product,
+                    path=self.temp_files[cache_key],
+                    url=self._get_product_url(timestamp, product),
+                    cached=True,
+                )
 
             # Download to temporary file
             url = self._get_product_url(timestamp, product)
 
-            # Create a proper temporary file
             with tempfile.NamedTemporaryFile(
                 suffix=f"_chmi_{product}_{timestamp}.hdf", delete=False
             ) as temp_file:
-                # Download directly to temp file
                 response = requests.get(url, timeout=30)
                 response.raise_for_status()
-
                 temp_file.write(response.content)
                 temp_path = Path(temp_file.name)
 
             # Track the temporary file
             self.temp_files[cache_key] = str(temp_path)
 
-            return {
-                "timestamp": timestamp,
-                "product": product,
-                "path": str(temp_path),
-                "url": url,
-                "cached": False,
-                "success": True,
-            }
+            return create_download_result(
+                timestamp=timestamp,
+                product=product,
+                path=str(temp_path),
+                url=url,
+                cached=False,
+            )
 
         except Exception as e:
-            return {
-                "error": str(e),
-                "timestamp": timestamp,
-                "product": product,
-                "success": False,
-            }
+            return create_error_result(timestamp, product, str(e))
+
+    def get_available_timestamps(
+        self,
+        count: int = 8,
+        products: list[str] = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+    ) -> list[str]:
+        """Get list of available CHMI timestamps WITHOUT downloading.
+
+        Args:
+            count: Maximum number of timestamps to return
+            products: List of products to check (default: ['maxz'])
+            start_time: Optional start time for filtering
+            end_time: Optional end time for filtering
+
+        Returns:
+            List of timestamp strings in YYYYMMDDHHMMSS format, newest first
+        """
+        # Generate candidate timestamps using shared utility
+        multiplier = 8 if (start_time and end_time) else 4
+        test_timestamps = generate_timestamp_candidates(
+            count=count * multiplier,
+            interval_minutes=5,
+            delay_minutes=0,  # CHMI is usually current
+            format_str=TimestampFormat.FULL,  # YYYYMMDDHHMMSS
+        )
+
+        # Filter by time range if specified
+        if start_time and end_time:
+            test_timestamps = filter_timestamps_by_range(
+                test_timestamps, start_time, end_time
+            )
+
+        # Find available timestamps
+        available_timestamps = []
+        for timestamp in test_timestamps:
+            if len(available_timestamps) >= count:
+                break
+            if self._check_timestamp_availability(timestamp, "maxz"):
+                available_timestamps.append(timestamp)
+
+        return available_timestamps
+
+    # download_timestamps is inherited from RadarSource base class
 
     def download_latest(
         self,
@@ -218,92 +207,33 @@ class CHMIRadarSource(RadarSource):
         if products is None:
             products = ["maxz"]  # Default product
 
-        logger.info(f"Finding last {count} available CHMI timestamps...", extra={"source": "chmi"})
+        logger.info(
+            f"Finding last {count} available CHMI timestamps...",
+            extra={"source": "chmi"},
+        )
+        logger.info(
+            "Checking CHMI server for current timestamps...",
+            extra={"source": "chmi"},
+        )
 
-        # Strategy: Check for current timestamps online
-        logger.info("Checking CHMI server for current timestamps...", extra={"source": "chmi"})
+        # Get available timestamps
+        available_timestamps = self.get_available_timestamps(
+            count=count,
+            products=products,
+            start_time=start_time,
+            end_time=end_time,
+        )
 
-        # Generate more timestamps if we're filtering by time range
-        multiplier = 8 if (start_time and end_time) else 4
-        test_timestamps = self._generate_timestamps(count * multiplier)
-
-        # Filter by time range if specified
-        if start_time and end_time:
-            test_timestamps = self._filter_timestamps_by_range(
-                test_timestamps, start_time, end_time
-            )
-            logger.info(
-                f"Filtered timestamps to range: {start_time.strftime('%Y-%m-%d %H:%M')} to {end_time.strftime('%Y-%m-%d %H:%M')}",
-                extra={"source": "chmi"},
-            )
-
-        available_timestamps = []
-
-        for timestamp in test_timestamps:
-            if len(available_timestamps) >= count:
-                break
-
-            # Test with maxz (only product)
-            if self._check_timestamp_availability(timestamp, "maxz"):
-                available_timestamps.append(timestamp)
-                logger.info(f"Found current: {timestamp}", extra={"source": "chmi"})
+        # Log found timestamps
+        for ts in available_timestamps:
+            logger.info(f"Found current: {ts}", extra={"source": "chmi"})
 
         if not available_timestamps:
             logger.warning("No available timestamps found", extra={"source": "chmi"})
             return []
 
-        logger.info(
-            f"Downloading {len(available_timestamps)} timestamps × {len(products)} products...",
-            extra={"source": "chmi"},
-        )
-
-        # Create download tasks
-        download_tasks = []
-        for timestamp in available_timestamps:
-            for product in products:
-                download_tasks.append((timestamp, product))
-
-        logger.info(
-            f"Starting parallel downloads ({len(download_tasks)} files, max 6 concurrent)...",
-            extra={"source": "chmi"},
-        )
-
-        # Execute downloads in parallel
-        downloaded_files = []
-        with ThreadPoolExecutor(max_workers=6) as executor:
-            # Submit all download tasks
-            future_to_task = {
-                executor.submit(self._download_single_file, timestamp, product): (
-                    timestamp,
-                    product,
-                )
-                for timestamp, product in download_tasks
-            }
-
-            # Process completed downloads
-            for future in as_completed(future_to_task):
-                timestamp, product = future_to_task[future]
-                try:
-                    result = future.result()
-                    if result["success"]:
-                        downloaded_files.append(result)
-                        if result["cached"]:
-                            logger.debug(f"Using cached: {product} {timestamp}", extra={"source": "chmi"})
-                        else:
-                            logger.info(f"Downloaded: {product} {timestamp}", extra={"source": "chmi"})
-                    else:
-                        logger.error(
-                            f"Failed {product} {timestamp}: {result.get('error', 'Unknown error')}",
-                            extra={"source": "chmi"},
-                        )
-                except Exception as e:
-                    logger.error(f"Exception {product} {timestamp}: {e}", extra={"source": "chmi"})
-
-        logger.info(
-            f"CHMI: Downloaded {len(downloaded_files)} files ({len(download_tasks) - len(downloaded_files)} failed)",
-            extra={"source": "chmi", "count": len(downloaded_files)},
-        )
-        return downloaded_files
+        # Download the timestamps
+        return self.download_timestamps(available_timestamps, products)
 
     def process_to_array(self, file_path: str) -> dict[str, Any]:
         """Process CHMI HDF5 file to array with metadata"""
@@ -313,39 +243,31 @@ class CHMIRadarSource(RadarSource):
                 # Read raw data
                 data = f["dataset1/data1/data"][:]
 
-                # Get attributes - CHMI stores scaling in data1/what (unlike SHMU)
-                what_attrs = dict(f["dataset1/data1/what"].attrs)
-                what_dataset_attrs = dict(
-                    f["dataset1/what"].attrs
+                # Get and decode attributes - CHMI stores scaling in data1/what
+                what_attrs = decode_hdf5_attrs(dict(f["dataset1/data1/what"].attrs))
+                what_dataset_attrs = decode_hdf5_attrs(
+                    dict(f["dataset1/what"].attrs)
                 )  # For product/timestamp
-                where_attrs = dict(f["where"].attrs)
+                where_attrs = decode_hdf5_attrs(dict(f["where"].attrs))
 
-                # Decode byte strings
-                for attr_dict in [what_attrs, what_dataset_attrs, where_attrs]:
-                    for key, value in attr_dict.items():
-                        if isinstance(value, bytes):
-                            attr_dict[key] = value.decode("utf-8")
+                # Get scaling parameters and scale data
+                scaling = get_scaling_params(
+                    what_attrs,
+                    default_nodata=-32768,
+                    default_undetect=0,
+                )
 
-                # Apply scaling
-                gain = what_attrs.get("gain", 1.0)
-                offset = what_attrs.get("offset", 0.0)
-                nodata = what_attrs.get("nodata", -32768)
-                undetect = what_attrs.get("undetect", 0)
-
-                # Scale data
-                scaled_data = data.astype(np.float32) * gain + offset
-
-                # Handle special values
-                # For CHMI uint8 data, 255 is the actual nodata marker (max uint8 value)
-                if data.dtype == np.uint8:
-                    scaled_data[data == 255] = np.nan  # 255 is nodata for uint8
-                else:
-                    scaled_data[data == nodata] = np.nan
-                scaled_data[data == undetect] = np.nan
+                scaled_data = scale_radar_data(
+                    data,
+                    scaling["gain"],
+                    scaling["offset"],
+                    scaling["nodata"],
+                    scaling["undetect"],
+                    handle_uint8=True,  # CHMI uses 255 as nodata for uint8
+                )
 
                 # Get corner coordinates from where attributes
                 # CHMI uses similar structure to SHMU (LL_lon/lat, UR_lon/lat)
-                # If not available, try projdef attributes
                 if "LL_lon" in where_attrs and "UR_lon" in where_attrs:
                     ll_lon = float(where_attrs["LL_lon"])
                     ll_lat = float(where_attrs["LL_lat"])
@@ -378,10 +300,10 @@ class CHMIRadarSource(RadarSource):
                         "quantity": quantity,
                         "timestamp": timestamp,
                         "source": "CHMI",
-                        "units": self._get_units(quantity),
+                        "units": get_quantity_units(quantity),
                         "nodata_value": np.nan,
-                        "gain": gain,
-                        "offset": offset,
+                        "gain": scaling["gain"],
+                        "offset": scaling["offset"],
                     },
                     "extent": {
                         "wgs84": {
@@ -399,11 +321,6 @@ class CHMIRadarSource(RadarSource):
 
         except Exception as e:
             raise RuntimeError(f"Failed to process CHMI file {file_path}: {e}")
-
-    def _get_units(self, quantity: str) -> str:
-        """Get units for a quantity"""
-        units_map = {"DBZH": "dBZ", "TH": "dBZ"}
-        return units_map.get(quantity, "dBZ")  # Default to dBZ for reflectivity
 
     def get_extent(self) -> dict[str, Any]:
         """Get CHMI radar coverage extent"""

--- a/src/imeteo_radar/utils/hdf5_utils.py
+++ b/src/imeteo_radar/utils/hdf5_utils.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+HDF5 processing utilities for ODIM_H5 radar data.
+
+Consolidates common HDF5 reading, attribute extraction, and data scaling
+logic that was duplicated across source classes (DWD, SHMU, CHMI, IMGW).
+"""
+
+from typing import Any
+
+import h5py
+import numpy as np
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def decode_hdf5_attrs(attrs: dict) -> dict[str, Any]:
+    """Decode HDF5 attributes, converting bytes to strings.
+
+    Args:
+        attrs: Dictionary of HDF5 attributes (may contain bytes)
+
+    Returns:
+        Dictionary with bytes decoded to strings
+    """
+    decoded = {}
+    for key, value in attrs.items():
+        if isinstance(value, bytes):
+            decoded[key] = value.decode("utf-8")
+        elif isinstance(value, np.bytes_):
+            decoded[key] = value.decode("utf-8")
+        else:
+            decoded[key] = value
+    return decoded
+
+
+def get_scaling_params(
+    data_what_attrs: dict,
+    default_gain: float = 1.0,
+    default_offset: float = 0.0,
+    default_nodata: int = 65535,
+    default_undetect: int = 0,
+) -> dict[str, float | int]:
+    """Extract scaling parameters from HDF5 data/what attributes.
+
+    Args:
+        data_what_attrs: Attributes from dataset1/data1/what
+        default_gain: Default gain value
+        default_offset: Default offset value
+        default_nodata: Default nodata value
+        default_undetect: Default undetect value
+
+    Returns:
+        Dictionary with gain, offset, nodata, undetect values
+    """
+    return {
+        "gain": float(data_what_attrs.get("gain", default_gain)),
+        "offset": float(data_what_attrs.get("offset", default_offset)),
+        "nodata": int(data_what_attrs.get("nodata", default_nodata)),
+        "undetect": int(data_what_attrs.get("undetect", default_undetect)),
+    }
+
+
+def scale_radar_data(
+    data: np.ndarray,
+    gain: float,
+    offset: float,
+    nodata: int | float,
+    undetect: int | float,
+    handle_uint8: bool = False,
+) -> np.ndarray:
+    """Scale radar data using gain and offset, handling special values.
+
+    Applies the standard ODIM_H5 scaling formula: value = gain * data + offset
+
+    Args:
+        data: Raw data array from HDF5
+        gain: Scaling gain factor
+        offset: Scaling offset
+        nodata: Value indicating no data (set to NaN)
+        undetect: Value indicating no detection (set to NaN)
+        handle_uint8: If True, also handle 255 as nodata for uint8 arrays
+
+    Returns:
+        Scaled data array with special values as NaN
+    """
+    # Apply scaling
+    scaled_data = data.astype(np.float32) * gain + offset
+
+    # Handle special values
+    scaled_data[data == nodata] = np.nan
+    scaled_data[data == undetect] = np.nan
+
+    # Handle uint8 255 value (common for no-data in some sources)
+    if handle_uint8 and data.dtype == np.uint8:
+        scaled_data[data == 255] = np.nan
+
+    return scaled_data
+
+
+def extract_corner_coordinates(
+    where_attrs: dict,
+    fallback_extent: dict[str, float] | None = None,
+) -> dict[str, float]:
+    """Extract corner coordinates from HDF5 where attributes.
+
+    Args:
+        where_attrs: Attributes from 'where' group
+        fallback_extent: Fallback extent if coordinates not found
+            Format: {"west": float, "east": float, "south": float, "north": float}
+
+    Returns:
+        Dictionary with west, east, south, north coordinates
+    """
+    # Try to extract coordinates from where attributes
+    ll_lon = where_attrs.get("LL_lon") or where_attrs.get("ll_lon")
+    ll_lat = where_attrs.get("LL_lat") or where_attrs.get("ll_lat")
+    ur_lon = where_attrs.get("UR_lon") or where_attrs.get("ur_lon")
+    ur_lat = where_attrs.get("UR_lat") or where_attrs.get("ur_lat")
+
+    # Check if all coordinates are present
+    if all(v is not None for v in [ll_lon, ll_lat, ur_lon, ur_lat]):
+        return {
+            "west": float(ll_lon),
+            "east": float(ur_lon),
+            "south": float(ll_lat),
+            "north": float(ur_lat),
+        }
+
+    # Use fallback if provided
+    if fallback_extent:
+        logger.debug("Using fallback extent (coordinates not in HDF5)")
+        return fallback_extent
+
+    raise ValueError("Could not extract coordinates and no fallback provided")
+
+
+def create_coordinate_arrays(
+    extent: dict[str, float],
+    shape: tuple[int, int],
+    flip_lat: bool = True,
+) -> dict[str, np.ndarray]:
+    """Create longitude and latitude coordinate arrays.
+
+    Args:
+        extent: Dictionary with west, east, south, north
+        shape: Data array shape (rows, cols)
+        flip_lat: Whether to flip latitude array (north to south)
+
+    Returns:
+        Dictionary with 'lons' and 'lats' arrays
+    """
+    rows, cols = shape
+
+    lons = np.linspace(extent["west"], extent["east"], cols)
+    lats = np.linspace(extent["south"], extent["north"], rows)
+
+    if flip_lat:
+        lats = np.flip(lats)
+
+    return {"lons": lons, "lats": lats}
+
+
+def get_quantity_units(quantity: str) -> str:
+    """Get units for a radar quantity.
+
+    Args:
+        quantity: ODIM_H5 quantity string (e.g., "DBZH", "TH", "ACRR")
+
+    Returns:
+        Units string (e.g., "dBZ", "mm")
+    """
+    units_map = {
+        "DBZH": "dBZ",
+        "DBZ": "dBZ",
+        "TH": "dBZ",
+        "TV": "dBZ",
+        "HGHT": "km",
+        "ACRR": "mm",
+        "RATE": "mm/h",
+        "VRAD": "m/s",
+        "WRAD": "m/s",
+        "RHOHV": "ratio",
+        "ZDR": "dB",
+        "KDP": "deg/km",
+        "PHIDP": "deg",
+    }
+    return units_map.get(quantity.upper(), "unknown")
+
+
+def find_main_dataset(hdf_file: h5py.File) -> np.ndarray | None:
+    """Find the main data array in an HDF5 file.
+
+    Tries standard ODIM_H5 paths first, then searches for large arrays.
+
+    Args:
+        hdf_file: Open HDF5 file handle
+
+    Returns:
+        Data array or None if not found
+    """
+    # Standard ODIM_H5 paths to try
+    standard_paths = [
+        "dataset1/data1/data",
+        "dataset1/data/data",
+        "dataset/data1/data",
+        "dataset/data",
+        "data1/data",
+        "data",
+    ]
+
+    for path in standard_paths:
+        try:
+            data = hdf_file[path][:]
+            logger.debug(f"Found data at: {path}")
+            return data
+        except KeyError:
+            continue
+
+    # Search for any large 2D array
+    def find_large_array(group, min_size=10000):
+        for key in group.keys():
+            item = group[key]
+            if isinstance(item, h5py.Dataset):
+                if item.ndim == 2 and item.size > min_size:
+                    return item[:]
+            elif isinstance(item, h5py.Group):
+                result = find_large_array(item, min_size)
+                if result is not None:
+                    return result
+        return None
+
+    return find_large_array(hdf_file)
+
+
+def extract_odim_metadata(hdf_file: h5py.File) -> dict[str, Any]:
+    """Extract standard ODIM_H5 metadata from file.
+
+    Args:
+        hdf_file: Open HDF5 file handle
+
+    Returns:
+        Dictionary with extracted metadata
+    """
+    metadata = {}
+
+    # Extract root 'what' attributes
+    if "what" in hdf_file:
+        what_attrs = decode_hdf5_attrs(dict(hdf_file["what"].attrs))
+        metadata["source"] = what_attrs.get("source", "")
+        metadata["date"] = what_attrs.get("date", "")
+        metadata["time"] = what_attrs.get("time", "")
+        metadata["object"] = what_attrs.get("object", "")
+        metadata["version"] = what_attrs.get("version", "")
+
+    # Extract dataset1/what attributes
+    if "dataset1/what" in hdf_file:
+        ds_what_attrs = decode_hdf5_attrs(dict(hdf_file["dataset1/what"].attrs))
+        metadata["product"] = ds_what_attrs.get("product", "")
+        metadata["startdate"] = ds_what_attrs.get("startdate", "")
+        metadata["starttime"] = ds_what_attrs.get("starttime", "")
+        metadata["enddate"] = ds_what_attrs.get("enddate", "")
+        metadata["endtime"] = ds_what_attrs.get("endtime", "")
+
+    # Extract data1/what attributes (quantity info)
+    if "dataset1/data1/what" in hdf_file:
+        data_what_attrs = decode_hdf5_attrs(dict(hdf_file["dataset1/data1/what"].attrs))
+        metadata["quantity"] = data_what_attrs.get("quantity", "")
+        metadata["gain"] = data_what_attrs.get("gain", 1.0)
+        metadata["offset"] = data_what_attrs.get("offset", 0.0)
+        metadata["nodata"] = data_what_attrs.get("nodata", 65535)
+        metadata["undetect"] = data_what_attrs.get("undetect", 0)
+
+    # Extract where attributes (projection/extent)
+    where_group = None
+    if "where" in hdf_file:
+        where_group = hdf_file["where"]
+    elif "dataset1/where" in hdf_file:
+        where_group = hdf_file["dataset1/where"]
+
+    if where_group is not None:
+        where_attrs = decode_hdf5_attrs(dict(where_group.attrs))
+        metadata["projdef"] = where_attrs.get("projdef", "")
+        metadata["xsize"] = where_attrs.get("xsize", 0)
+        metadata["ysize"] = where_attrs.get("ysize", 0)
+        metadata["xscale"] = where_attrs.get("xscale", 0)
+        metadata["yscale"] = where_attrs.get("yscale", 0)
+
+    return metadata
+
+
+def process_odim_file(
+    file_path: str,
+    fallback_extent: dict[str, float],
+    source_name: str,
+    handle_uint8: bool = True,
+) -> dict[str, Any]:
+    """Process an ODIM_H5 file and return standardized radar data.
+
+    This is a common processing function that can be used by sources
+    that follow the ODIM_H5 standard (SHMU, CHMI, IMGW, etc.).
+
+    Args:
+        file_path: Path to HDF5 file
+        fallback_extent: Fallback extent if not in file
+        source_name: Source identifier for logging
+        handle_uint8: Handle 255 as nodata for uint8 arrays
+
+    Returns:
+        Standardized radar data dictionary
+    """
+    from .timestamps import extract_timestamp_from_hdf5_attrs
+
+    with h5py.File(file_path, "r") as f:
+        # Find main data array
+        data = find_main_dataset(f)
+        if data is None:
+            raise ValueError(f"Could not find data array in {file_path}")
+
+        # Get scaling parameters
+        data_what_attrs = {}
+        if "dataset1/data1/what" in f:
+            data_what_attrs = decode_hdf5_attrs(dict(f["dataset1/data1/what"].attrs))
+
+        scaling = get_scaling_params(data_what_attrs)
+
+        # Scale data
+        scaled_data = scale_radar_data(
+            data,
+            scaling["gain"],
+            scaling["offset"],
+            scaling["nodata"],
+            scaling["undetect"],
+            handle_uint8=handle_uint8,
+        )
+
+        # Get extent
+        where_attrs = {}
+        if "where" in f:
+            where_attrs = decode_hdf5_attrs(dict(f["where"].attrs))
+        elif "dataset1/where" in f:
+            where_attrs = decode_hdf5_attrs(dict(f["dataset1/where"].attrs))
+
+        try:
+            extent = extract_corner_coordinates(where_attrs, fallback_extent)
+        except ValueError:
+            extent = fallback_extent
+
+        # Create coordinate arrays
+        coordinates = create_coordinate_arrays(extent, data.shape)
+
+        # Extract timestamp
+        what_attrs = {}
+        ds_what_attrs = {}
+        if "what" in f:
+            what_attrs = decode_hdf5_attrs(dict(f["what"].attrs))
+        if "dataset1/what" in f:
+            ds_what_attrs = decode_hdf5_attrs(dict(f["dataset1/what"].attrs))
+
+        # Try dataset what first, then root what
+        timestamp = extract_timestamp_from_hdf5_attrs(
+            ds_what_attrs if ds_what_attrs else what_attrs
+        )
+
+        # Get quantity
+        quantity = data_what_attrs.get("quantity", "DBZH")
+        units = get_quantity_units(quantity)
+
+        return {
+            "data": scaled_data,
+            "coordinates": coordinates,
+            "metadata": {
+                "product": ds_what_attrs.get("product", "UNKNOWN"),
+                "quantity": quantity,
+                "timestamp": timestamp,
+                "source": source_name.upper(),
+                "units": units,
+                "nodata_value": np.nan,
+            },
+            "extent": {"wgs84": extent},
+            "dimensions": data.shape,
+            "timestamp": timestamp,
+        }
+
+
+def extract_extent_only(
+    file_path: str,
+    fallback_extent: dict[str, float],
+) -> dict[str, Any]:
+    """Extract extent from ODIM_H5 file without loading data array.
+
+    Memory-efficient method that reads only metadata.
+
+    Args:
+        file_path: Path to HDF5 file
+        fallback_extent: Fallback extent if not in file
+
+    Returns:
+        Dictionary with extent and dimensions
+    """
+    with h5py.File(file_path, "r") as f:
+        # Get where attributes
+        where_attrs = {}
+        if "where" in f:
+            where_attrs = decode_hdf5_attrs(dict(f["where"].attrs))
+        elif "dataset1/where" in f:
+            where_attrs = decode_hdf5_attrs(dict(f["dataset1/where"].attrs))
+
+        try:
+            extent = extract_corner_coordinates(where_attrs, fallback_extent)
+        except ValueError:
+            extent = fallback_extent
+
+        # Get dimensions without loading data
+        dimensions = None
+        if "dataset1/data1/data" in f:
+            dimensions = f["dataset1/data1/data"].shape
+        elif "dataset1/data/data" in f:
+            dimensions = f["dataset1/data/data"].shape
+
+        if dimensions is None:
+            # Fallback to xsize/ysize from where attrs
+            xsize = where_attrs.get("xsize", 0)
+            ysize = where_attrs.get("ysize", 0)
+            if xsize and ysize:
+                dimensions = (int(ysize), int(xsize))
+
+        return {
+            "extent": {"wgs84": extent},
+            "dimensions": dimensions,
+        }

--- a/src/imeteo_radar/utils/parallel_download.py
+++ b/src/imeteo_radar/utils/parallel_download.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Parallel download utilities for radar data sources.
+
+Consolidates the ThreadPoolExecutor pattern that was duplicated
+across all source classes (DWD, SHMU, CHMI, OMSZ, IMGW).
+"""
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def execute_parallel_downloads(
+    tasks: list[tuple],
+    download_func: Callable,
+    source_name: str,
+    max_workers: int = 6,
+) -> list[dict[str, Any]]:
+    """Execute downloads in parallel using ThreadPoolExecutor.
+
+    Args:
+        tasks: List of (timestamp, product) tuples to download
+        download_func: Function to call for each download, signature: (timestamp, product) -> dict
+        source_name: Name of the source for logging
+        max_workers: Maximum concurrent downloads (default: 6)
+
+    Returns:
+        List of successful download results
+    """
+    if not tasks:
+        return []
+
+    logger.debug(
+        f"Starting parallel downloads ({len(tasks)} files, max {max_workers} concurrent)..."
+    )
+
+    downloaded_files = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all download tasks
+        future_to_task = {
+            executor.submit(download_func, timestamp, product): (timestamp, product)
+            for timestamp, product in tasks
+        }
+
+        # Process completed downloads
+        for future in as_completed(future_to_task):
+            timestamp, product = future_to_task[future]
+            try:
+                result = future.result()
+                if result.get("success", False):
+                    downloaded_files.append(result)
+                    cached_indicator = " (cached)" if result.get("cached") else ""
+                    logger.debug(f"Downloaded: {product} {timestamp}{cached_indicator}")
+                else:
+                    error = result.get("error", "Unknown error")
+                    logger.warning(f"Failed {product} {timestamp}: {error}")
+            except Exception as e:
+                logger.warning(f"Exception {product} {timestamp}: {e}")
+
+    success_count = len(downloaded_files)
+    fail_count = len(tasks) - success_count
+    logger.info(
+        f"{source_name.upper()}: Downloaded {success_count} files ({fail_count} failed)",
+        extra={"source": source_name, "count": success_count},
+    )
+
+    return downloaded_files
+
+
+class SessionCache:
+    """Simple session-level cache for downloaded files.
+
+    Prevents downloading the same file twice within a single session.
+    Used by source classes to track temp files.
+    """
+
+    def __init__(self):
+        self._cache: dict[str, str] = {}
+
+    def get_cache_key(self, timestamp: str, product: str) -> str:
+        """Generate cache key for a timestamp/product pair."""
+        return f"{product}_{timestamp}"
+
+    def is_cached(self, timestamp: str, product: str) -> bool:
+        """Check if file is already downloaded in this session."""
+        key = self.get_cache_key(timestamp, product)
+        return key in self._cache and os.path.exists(self._cache[key])
+
+    def get_cached_path(self, timestamp: str, product: str) -> str | None:
+        """Get path to cached file if it exists."""
+        key = self.get_cache_key(timestamp, product)
+        if key in self._cache and os.path.exists(self._cache[key]):
+            return self._cache[key]
+        return None
+
+    def add(self, timestamp: str, product: str, file_path: str) -> None:
+        """Add file to session cache."""
+        key = self.get_cache_key(timestamp, product)
+        self._cache[key] = file_path
+
+    def get_cached_result(
+        self,
+        timestamp: str,
+        product: str,
+        url: str = "",
+    ) -> dict[str, Any] | None:
+        """Get a cached result dict if file exists.
+
+        Returns:
+            Result dict with cached=True if found, None otherwise
+        """
+        cached_path = self.get_cached_path(timestamp, product)
+        if cached_path:
+            return {
+                "timestamp": timestamp,
+                "product": product,
+                "path": cached_path,
+                "url": url,
+                "cached": True,
+                "success": True,
+            }
+        return None
+
+    def cleanup(self) -> int:
+        """Remove all cached temp files.
+
+        Returns:
+            Number of files removed
+        """
+        removed = 0
+        for path in self._cache.values():
+            try:
+                if os.path.exists(path):
+                    Path(path).unlink()
+                    removed += 1
+            except Exception:
+                pass
+        self._cache.clear()
+        return removed
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._cache
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self._cache[key] = value
+
+    def __getitem__(self, key: str) -> str:
+        return self._cache[key]
+
+    def keys(self):
+        return self._cache.keys()
+
+    def values(self):
+        return self._cache.values()
+
+    def items(self):
+        return self._cache.items()
+
+
+def create_download_result(
+    timestamp: str,
+    product: str,
+    path: str,
+    url: str = "",
+    cached: bool = False,
+    success: bool = True,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Create a standardized download result dictionary.
+
+    Args:
+        timestamp: Timestamp of the downloaded data
+        product: Product identifier
+        path: Path to the downloaded file
+        url: Source URL
+        cached: Whether the file was from cache
+        success: Whether the download succeeded
+        error: Error message if failed
+
+    Returns:
+        Standardized result dictionary
+    """
+    result = {
+        "timestamp": timestamp,
+        "product": product,
+        "path": path,
+        "url": url,
+        "cached": cached,
+        "success": success,
+    }
+    if error:
+        result["error"] = error
+    return result
+
+
+def create_error_result(
+    timestamp: str,
+    product: str,
+    error: str,
+) -> dict[str, Any]:
+    """Create a standardized error result dictionary.
+
+    Args:
+        timestamp: Timestamp of the failed download
+        product: Product identifier
+        error: Error message
+
+    Returns:
+        Standardized error result dictionary
+    """
+    return {
+        "timestamp": timestamp,
+        "product": product,
+        "path": "",
+        "url": "",
+        "cached": False,
+        "success": False,
+        "error": error,
+    }

--- a/src/imeteo_radar/utils/processed_cache.py
+++ b/src/imeteo_radar/utils/processed_cache.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+"""
+Processed Radar Data Cache
+
+Dual-layer caching system for processed radar data arrays.
+Solves the timestamp mismatch problem where fast sources (ARSO ~7-8 min latency)
+get dropped from composites because slow sources (SHMU/OMSZ/IMGW ~13 min) haven't
+caught up yet.
+
+Storage Layers:
+- Layer 1: Local filesystem (/tmp) - fast, ephemeral
+- Layer 2: S3/DO Spaces - persistent across pod restarts (production K8s)
+
+Storage Format:
+- Local: /tmp/iradar-data/{source}/{source}_{product}_{timestamp}.npz
+- S3: iradar-data/{source}/{source}_{product}_{timestamp}.npz
+- NPZ file containing: data (2D float32), lons, lats arrays
+- JSON metadata file alongside with extent, dimensions, cached_at timestamp
+"""
+
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProcessedDataCache:
+    """Dual-layer cache for processed radar data arrays.
+
+    Layer 1: Local filesystem (/tmp) - fast, ephemeral
+    Layer 2: S3/DO Spaces - persistent across pod restarts
+
+    Usage:
+        cache = ProcessedDataCache()
+
+        # Check for cached data
+        cached = cache.get("arso", "202501281005", "zm")
+        if cached:
+            radar_data = cached
+        else:
+            radar_data = source.process_to_array(file_path)
+            cache.put("arso", radar_data["timestamp"], "zm", radar_data)
+
+        # Get timestamps available in cache for matching
+        available = cache.get_available_timestamps("arso", "zm")
+    """
+
+    def __init__(
+        self,
+        local_dir: Path | None = None,
+        ttl_minutes: int = 60,
+        s3_enabled: bool = True,
+    ):
+        """Initialize the processed data cache.
+
+        Args:
+            local_dir: Local cache directory (default: /tmp/radar_cache)
+            ttl_minutes: Time-to-live for cache entries in minutes (default: 60)
+            s3_enabled: Whether to use S3/DO Spaces as secondary layer
+        """
+        self.local_dir = local_dir or Path("/tmp/iradar-data")
+        self.ttl_minutes = ttl_minutes
+        self.s3_enabled = s3_enabled
+        self._uploader = None
+        self._s3_initialized = False
+
+        # Create local cache directory
+        self.local_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.debug(
+            f"ProcessedDataCache initialized: local_dir={self.local_dir}, "
+            f"ttl={ttl_minutes}min, s3_enabled={s3_enabled}"
+        )
+
+    def _get_uploader(self):
+        """Lazy-initialize S3 uploader."""
+        if not self.s3_enabled:
+            return None
+
+        if not self._s3_initialized:
+            self._s3_initialized = True
+            try:
+                from .spaces_uploader import SpacesUploader, is_spaces_configured
+
+                if is_spaces_configured():
+                    self._uploader = SpacesUploader()
+                    logger.debug("S3 cache layer enabled")
+                else:
+                    logger.debug("S3 not configured, using local cache only")
+            except Exception as e:
+                logger.warning(f"Failed to initialize S3 for cache: {e}")
+
+        return self._uploader
+
+    def _get_local_path(self, source: str, timestamp: str, product: str) -> Path:
+        """Get local cache file path for a given source/timestamp/product."""
+        source_dir = self.local_dir / source
+        source_dir.mkdir(parents=True, exist_ok=True)
+        # Normalize timestamp to 12 characters (YYYYMMDDHHMM)
+        ts_normalized = timestamp[:12]
+        return source_dir / f"{source}_{product}_{ts_normalized}.npz"
+
+    def _get_metadata_path(self, npz_path: Path) -> Path:
+        """Get metadata JSON path for a given NPZ file."""
+        return npz_path.with_suffix(".json")
+
+    def _get_s3_key(self, source: str, timestamp: str, product: str) -> str:
+        """Get S3 key for cache file."""
+        ts_normalized = timestamp[:12]
+        return f"iradar-data/{source}/{source}_{product}_{ts_normalized}.npz"
+
+    def _get_s3_metadata_key(self, source: str, timestamp: str, product: str) -> str:
+        """Get S3 key for metadata file."""
+        ts_normalized = timestamp[:12]
+        return f"iradar-data/{source}/{source}_{product}_{ts_normalized}.json"
+
+    def _is_expired(self, metadata_path: Path) -> bool:
+        """Check if a cache entry is expired based on its metadata."""
+        if not metadata_path.exists():
+            return True
+
+        try:
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+
+            cached_at = metadata.get("cached_at", 0)
+            age_minutes = (time.time() - cached_at) / 60
+
+            return age_minutes > self.ttl_minutes
+        except Exception:
+            return True
+
+    def exists(self, source: str, timestamp: str, product: str) -> bool:
+        """Check if valid (non-expired) cache entry exists.
+
+        Checks local cache first, then S3 if enabled.
+
+        Args:
+            source: Source identifier (e.g., 'arso', 'shmu')
+            timestamp: Timestamp string (YYYYMMDDHHMM format)
+            product: Product identifier (e.g., 'zm', 'zmax')
+
+        Returns:
+            True if valid cache entry exists, False otherwise
+        """
+        local_path = self._get_local_path(source, timestamp, product)
+        metadata_path = self._get_metadata_path(local_path)
+
+        # Check local cache first
+        if local_path.exists() and metadata_path.exists():
+            if not self._is_expired(metadata_path):
+                return True
+
+        # Check S3 if local miss
+        if self._get_uploader():
+            npz_key = self._get_s3_key(source, timestamp, product)
+            try:
+                self._get_uploader().s3_client.head_object(
+                    Bucket=self._get_uploader().bucket, Key=npz_key
+                )
+                return True
+            except Exception:
+                pass
+
+        return False
+
+    def get(self, source: str, timestamp: str, product: str) -> dict[str, Any] | None:
+        """Get cached radar data for a source/timestamp/product.
+
+        Lookup order:
+        1. Check local cache (fast)
+        2. If miss, check S3 and download to local (slower, but persistent)
+
+        Args:
+            source: Source identifier (e.g., 'arso', 'shmu')
+            timestamp: Timestamp string (YYYYMMDDHHMM format)
+            product: Product identifier (e.g., 'zm', 'zmax')
+
+        Returns:
+            Dictionary with radar data or None if not found/expired
+        """
+        local_path = self._get_local_path(source, timestamp, product)
+        metadata_path = self._get_metadata_path(local_path)
+
+        # Try local cache first
+        if local_path.exists() and metadata_path.exists():
+            if not self._is_expired(metadata_path):
+                try:
+                    return self._load_from_local(local_path, metadata_path)
+                except Exception as e:
+                    logger.warning(f"Failed to load from local cache: {e}")
+
+        # Try S3 if local miss
+        if self._get_uploader():
+            downloaded = self._download_from_s3(source, timestamp, product)
+            if downloaded:
+                # Verify it's not expired after download
+                if not self._is_expired(metadata_path):
+                    try:
+                        return self._load_from_local(local_path, metadata_path)
+                    except Exception as e:
+                        logger.warning(f"Failed to load downloaded cache: {e}")
+
+        return None
+
+    def _load_from_local(self, npz_path: Path, metadata_path: Path) -> dict[str, Any]:
+        """Load radar data from local cache files."""
+        # Load NPZ data
+        with np.load(npz_path) as npz:
+            data = npz["data"]
+            lons = npz.get("lons")
+            lats = npz.get("lats")
+
+        # Load metadata
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+
+        # Reconstruct radar_data dict (matching format from source.process_to_array())
+        radar_data = {
+            "data": data,
+            "extent": metadata.get("extent", {}),
+            "metadata": metadata.get("source_metadata", {}),
+            "timestamp": metadata.get("timestamp", ""),
+            "dimensions": tuple(metadata.get("dimensions", list(data.shape))),
+        }
+
+        # Reconstruct coordinates dict (required by compositor)
+        if lons is not None and lats is not None:
+            radar_data["coordinates"] = {"lons": lons, "lats": lats}
+        else:
+            # Set to None so compositor will generate from metadata
+            radar_data["coordinates"] = None
+
+        logger.debug(
+            f"Cache hit: {npz_path.name}",
+            extra={
+                "source": metadata.get("source"),
+                "timestamp": metadata.get("timestamp"),
+            },
+        )
+
+        return radar_data
+
+    def put(
+        self,
+        source: str,
+        timestamp: str,
+        product: str,
+        radar_data: dict[str, Any],
+        force: bool = False,
+    ) -> Path | None:
+        """Save processed radar data to cache.
+
+        Saves to local first, then uploads to S3 if enabled.
+        Skips saving if valid cache entry already exists (unless force=True).
+
+        Args:
+            source: Source identifier (e.g., 'arso', 'shmu')
+            timestamp: Timestamp string (YYYYMMDDHHMM format)
+            product: Product identifier (e.g., 'zm', 'zmax')
+            radar_data: Dictionary from source.process_to_array()
+            force: If True, overwrite existing cache entry
+
+        Returns:
+            Path to the local cache file, or None if skipped
+        """
+        local_path = self._get_local_path(source, timestamp, product)
+        metadata_path = self._get_metadata_path(local_path)
+
+        # Skip if valid cache entry already exists
+        if not force and local_path.exists() and metadata_path.exists():
+            if not self._is_expired(metadata_path):
+                logger.debug(
+                    f"Cache entry already exists: {local_path.name}",
+                    extra={"source": source, "timestamp": timestamp},
+                )
+                return local_path
+
+        # Save NPZ with data arrays
+        data = radar_data["data"]
+        save_dict = {"data": data.astype(np.float32)}
+
+        # Extract coordinates from the nested structure (radar_data["coordinates"])
+        coordinates = radar_data.get("coordinates")
+        if coordinates is not None:
+            if "lons" in coordinates:
+                save_dict["lons"] = coordinates["lons"]
+            if "lats" in coordinates:
+                save_dict["lats"] = coordinates["lats"]
+
+        np.savez_compressed(local_path, **save_dict)
+
+        # Save metadata
+        metadata = {
+            "source": source,
+            "timestamp": timestamp,
+            "product": product,
+            "extent": radar_data.get("extent", {}),
+            "dimensions": list(data.shape),
+            "source_metadata": radar_data.get("metadata", {}),
+            "cached_at": time.time(),
+            "cached_at_iso": datetime.utcnow().isoformat() + "Z",
+        }
+
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        logger.info(
+            f"Cached: {local_path.name}",
+            extra={"source": source, "timestamp": timestamp, "product": product},
+        )
+
+        # Upload to S3 if enabled
+        if self._get_uploader():
+            self._upload_to_s3(local_path, metadata_path, source, timestamp, product)
+
+        return local_path
+
+    def _upload_to_s3(
+        self,
+        local_path: Path,
+        metadata_path: Path,
+        source: str,
+        timestamp: str,
+        product: str,
+    ):
+        """Upload cache files to S3."""
+        uploader = self._get_uploader()
+        if not uploader:
+            return
+
+        try:
+            # Upload NPZ file
+            npz_key = self._get_s3_key(source, timestamp, product)
+            uploader.s3_client.upload_file(
+                str(local_path),
+                uploader.bucket,
+                npz_key,
+                ExtraArgs={"ContentType": "application/octet-stream"},
+            )
+
+            # Upload metadata JSON
+            json_key = self._get_s3_metadata_key(source, timestamp, product)
+            uploader.s3_client.upload_file(
+                str(metadata_path),
+                uploader.bucket,
+                json_key,
+                ExtraArgs={"ContentType": "application/json"},
+            )
+
+            logger.debug(f"Uploaded to S3: {npz_key}")
+
+        except Exception as e:
+            logger.warning(f"Failed to upload cache to S3: {e}")
+
+    def _download_from_s3(
+        self, source: str, timestamp: str, product: str
+    ) -> Path | None:
+        """Download cache files from S3 to local cache.
+
+        Returns:
+            Local path if download successful, None otherwise
+        """
+        uploader = self._get_uploader()
+        if not uploader:
+            return None
+
+        local_path = self._get_local_path(source, timestamp, product)
+        metadata_path = self._get_metadata_path(local_path)
+        npz_key = self._get_s3_key(source, timestamp, product)
+        json_key = self._get_s3_metadata_key(source, timestamp, product)
+
+        try:
+            # Check if file exists in S3
+            uploader.s3_client.head_object(Bucket=uploader.bucket, Key=npz_key)
+
+            # Download both files
+            uploader.s3_client.download_file(uploader.bucket, npz_key, str(local_path))
+            uploader.s3_client.download_file(
+                uploader.bucket, json_key, str(metadata_path)
+            )
+
+            logger.debug(f"Downloaded from S3: {npz_key}")
+            return local_path
+
+        except Exception:
+            # File doesn't exist in S3 or download failed
+            return None
+
+    def get_available_timestamps(
+        self, source: str, product: str | None = None
+    ) -> list[str]:
+        """Get all available timestamps for a source from both cache layers.
+
+        Args:
+            source: Source identifier (e.g., 'arso', 'shmu')
+            product: Optional product filter (e.g., 'zm', 'zmax')
+
+        Returns:
+            List of timestamp strings (YYYYMMDDHHMM format), sorted newest first
+        """
+        timestamps = set()
+
+        # Get from local cache
+        source_dir = self.local_dir / source
+        if source_dir.exists():
+            for npz_file in source_dir.glob("*.npz"):
+                metadata_path = self._get_metadata_path(npz_file)
+                if self._is_expired(metadata_path):
+                    continue
+
+                # Parse filename: {source}_{product}_{timestamp}.npz
+                parts = npz_file.stem.split("_")
+                if len(parts) >= 3:
+                    file_product = parts[1]
+                    file_timestamp = parts[2]
+
+                    if product is None or file_product == product:
+                        timestamps.add(file_timestamp)
+
+        # Get from S3 (if enabled and configured)
+        if self._get_uploader():
+            s3_timestamps = self._get_s3_timestamps(source, product)
+            timestamps.update(s3_timestamps)
+
+        # Sort newest first
+        return sorted(timestamps, reverse=True)
+
+    def _get_s3_timestamps(self, source: str, product: str | None = None) -> set[str]:
+        """Get available timestamps from S3 cache."""
+        uploader = self._get_uploader()
+        if not uploader:
+            return set()
+
+        timestamps = set()
+        prefix = f"iradar-data/{source}/"
+
+        try:
+            paginator = uploader.s3_client.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=uploader.bucket, Prefix=prefix):
+                for obj in page.get("Contents", []):
+                    key = obj["Key"]
+                    if not key.endswith(".npz"):
+                        continue
+
+                    # Parse key: iradar/cache/{source}/{source}_{product}_{timestamp}.npz
+                    filename = key.split("/")[-1]
+                    parts = filename.replace(".npz", "").split("_")
+                    if len(parts) >= 3:
+                        file_product = parts[1]
+                        file_timestamp = parts[2]
+
+                        if product is None or file_product == product:
+                            timestamps.add(file_timestamp)
+
+        except Exception as e:
+            logger.warning(f"Failed to list S3 cache: {e}")
+
+        return timestamps
+
+    def cleanup_expired(self) -> int:
+        """Remove expired cache entries from local cache and S3.
+
+        Returns:
+            Number of entries removed (local + S3)
+        """
+        local_removed = self._cleanup_local_expired()
+        s3_removed = self._cleanup_s3_expired()
+
+        total_removed = local_removed + s3_removed
+        if total_removed > 0:
+            logger.info(
+                f"Cache cleanup: removed {local_removed} local + {s3_removed} S3 entries"
+            )
+
+        return total_removed
+
+    def _cleanup_local_expired(self) -> int:
+        """Remove expired cache entries from local filesystem."""
+        removed = 0
+
+        if not self.local_dir.exists():
+            return 0
+
+        for source_dir in self.local_dir.iterdir():
+            if not source_dir.is_dir():
+                continue
+
+            for npz_file in source_dir.glob("*.npz"):
+                metadata_path = self._get_metadata_path(npz_file)
+
+                if self._is_expired(metadata_path):
+                    try:
+                        npz_file.unlink(missing_ok=True)
+                        metadata_path.unlink(missing_ok=True)
+                        removed += 1
+                        logger.debug(f"Removed expired local cache: {npz_file.name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to remove expired cache: {e}")
+
+        return removed
+
+    def _cleanup_s3_expired(self) -> int:
+        """Remove expired cache entries from S3/DO Spaces."""
+        uploader = self._get_uploader()
+        if not uploader:
+            return 0
+
+        removed = 0
+        cutoff_time = time.time() - (self.ttl_minutes * 60)
+
+        try:
+            # List all objects in the cache prefix
+            paginator = uploader.s3_client.get_paginator("list_objects_v2")
+            objects_to_delete = []
+
+            for page in paginator.paginate(
+                Bucket=uploader.bucket, Prefix="iradar-data/"
+            ):
+                for obj in page.get("Contents", []):
+                    key = obj["Key"]
+
+                    # Check age using S3 LastModified
+                    last_modified = obj.get("LastModified")
+                    if last_modified:
+                        # Convert to timestamp
+                        obj_timestamp = last_modified.timestamp()
+                        if obj_timestamp < cutoff_time:
+                            objects_to_delete.append({"Key": key})
+
+            # Delete expired objects in batches of 1000 (S3 limit)
+            if objects_to_delete:
+                for i in range(0, len(objects_to_delete), 1000):
+                    batch = objects_to_delete[i : i + 1000]
+                    uploader.s3_client.delete_objects(
+                        Bucket=uploader.bucket, Delete={"Objects": batch}
+                    )
+                    removed += len(batch)
+                    logger.debug(f"Deleted {len(batch)} expired S3 cache objects")
+
+        except Exception as e:
+            logger.warning(f"Failed to cleanup S3 cache: {e}")
+
+        return removed
+
+    def clear(self, source: str | None = None) -> int:
+        """Clear cache entries.
+
+        Args:
+            source: Optional source to clear (clears all if None)
+
+        Returns:
+            Number of entries removed
+        """
+        removed = 0
+
+        if source:
+            # Clear specific source
+            source_dir = self.local_dir / source
+            if source_dir.exists():
+                for f in source_dir.glob("*"):
+                    try:
+                        f.unlink()
+                        removed += 1
+                    except Exception:
+                        pass
+        else:
+            # Clear all
+            for source_dir in self.local_dir.iterdir():
+                if source_dir.is_dir():
+                    for f in source_dir.glob("*"):
+                        try:
+                            f.unlink()
+                            removed += 1
+                        except Exception:
+                            pass
+
+        # Count NPZ files only (metadata files are paired)
+        removed = removed // 2
+
+        if removed > 0:
+            logger.info(f"Cleared {removed} cache entries")
+
+        return removed
+
+    def get_cache_stats(self) -> dict[str, Any]:
+        """Get cache statistics.
+
+        Returns:
+            Dictionary with cache statistics
+        """
+        stats = {
+            "local_dir": str(self.local_dir),
+            "ttl_minutes": self.ttl_minutes,
+            "s3_enabled": self.s3_enabled and self._get_uploader() is not None,
+            "sources": {},
+        }
+
+        total_size = 0
+        total_entries = 0
+
+        for source_dir in self.local_dir.iterdir():
+            if not source_dir.is_dir():
+                continue
+
+            source_name = source_dir.name
+            source_entries = 0
+            source_size = 0
+
+            for npz_file in source_dir.glob("*.npz"):
+                metadata_path = self._get_metadata_path(npz_file)
+                if not self._is_expired(metadata_path):
+                    source_entries += 1
+                    source_size += npz_file.stat().st_size
+
+            if source_entries > 0:
+                stats["sources"][source_name] = {
+                    "entries": source_entries,
+                    "size_mb": round(source_size / (1024 * 1024), 2),
+                }
+                total_entries += source_entries
+                total_size += source_size
+
+        stats["total_entries"] = total_entries
+        stats["total_size_mb"] = round(total_size / (1024 * 1024), 2)
+
+        return stats

--- a/src/imeteo_radar/utils/timestamps.py
+++ b/src/imeteo_radar/utils/timestamps.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Timestamp utilities for radar data processing.
+
+Centralizes all timestamp parsing, normalization, and generation logic
+that was previously duplicated across source classes.
+"""
+
+from datetime import datetime, timedelta
+from typing import Callable
+
+import pytz
+
+from ..core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Standard timestamp formats used by different sources
+class TimestampFormat:
+    """Standard timestamp format definitions."""
+
+    # 14-digit format: YYYYMMDDHHMMSS
+    FULL = "%Y%m%d%H%M%S"
+    # 12-digit format: YYYYMMDDHHMM
+    SHORT = "%Y%m%d%H%M"
+    # DWD/OMSZ format: YYYYMMDD_HHMM
+    UNDERSCORE = "%Y%m%d_%H%M"
+    # 8-digit date: YYYYMMDD
+    DATE_ONLY = "%Y%m%d"
+    # 6-digit time: HHMMSS
+    TIME_ONLY = "%H%M%S"
+
+
+def parse_timestamp(ts_str: str, fmt: str | None = None) -> datetime | None:
+    """Parse a timestamp string to datetime.
+
+    Args:
+        ts_str: Timestamp string to parse
+        fmt: Optional format string. If None, auto-detects format.
+
+    Returns:
+        Parsed datetime or None if parsing fails
+    """
+    if fmt:
+        try:
+            return datetime.strptime(ts_str, fmt)
+        except ValueError:
+            return None
+
+    # Auto-detect format based on string pattern
+    formats_to_try = [
+        (TimestampFormat.FULL, 14),  # YYYYMMDDHHMMSS
+        (TimestampFormat.SHORT, 12),  # YYYYMMDDHHMM
+        (TimestampFormat.UNDERSCORE, 13),  # YYYYMMDD_HHMM
+    ]
+
+    for fmt, expected_len in formats_to_try:
+        if len(ts_str) >= expected_len:
+            try:
+                return datetime.strptime(ts_str[:expected_len], fmt)
+            except ValueError:
+                continue
+
+    return None
+
+
+def normalize_timestamp(timestamp: str, target_length: int = 14) -> str:
+    """Normalize timestamp to standard length.
+
+    Args:
+        timestamp: Input timestamp string
+        target_length: Target length (12 or 14)
+
+    Returns:
+        Normalized timestamp string
+    """
+    # Remove underscores if present (DWD/OMSZ format)
+    ts = timestamp.replace("_", "")
+
+    if target_length == 14:
+        # Pad to 14 characters with "00" for seconds
+        if len(ts) == 12:
+            return ts + "00"
+        return ts[:14]
+    elif target_length == 12:
+        return ts[:12]
+
+    return ts
+
+
+def round_to_interval(dt: datetime, interval_minutes: int = 5) -> datetime:
+    """Round datetime down to nearest interval.
+
+    Args:
+        dt: Datetime to round
+        interval_minutes: Interval in minutes (default: 5)
+
+    Returns:
+        Rounded datetime
+    """
+    return dt.replace(
+        minute=(dt.minute // interval_minutes) * interval_minutes,
+        second=0,
+        microsecond=0,
+    )
+
+
+def generate_timestamp_candidates(
+    count: int,
+    interval_minutes: int = 5,
+    delay_minutes: int = 15,
+    format_str: str = TimestampFormat.SHORT,
+    timezone_offset_hours: int = 0,
+) -> list[str]:
+    """Generate candidate timestamps for checking data availability.
+
+    Args:
+        count: Number of timestamps to generate
+        interval_minutes: Interval between timestamps (default: 5)
+        delay_minutes: Minutes to subtract from current time for processing delay
+        format_str: Output format string
+        timezone_offset_hours: Offset from UTC (e.g., 1 for CET)
+
+    Returns:
+        List of timestamp strings, newest first
+    """
+    timestamps = []
+    current_time = datetime.now(pytz.UTC) - timedelta(minutes=delay_minutes)
+
+    if timezone_offset_hours:
+        current_time = current_time + timedelta(hours=timezone_offset_hours)
+
+    # Generate candidates going backwards
+    for minutes_back in range(0, count * interval_minutes * 3, interval_minutes):
+        check_time = current_time - timedelta(minutes=minutes_back)
+        check_time = round_to_interval(check_time, interval_minutes)
+        timestamp = check_time.strftime(format_str)
+
+        if timestamp not in timestamps:
+            timestamps.append(timestamp)
+
+        if len(timestamps) >= count * 3:
+            break
+
+    return timestamps
+
+
+def filter_timestamps_by_range(
+    timestamps: list[str],
+    start_time: datetime,
+    end_time: datetime,
+    parse_format: str | None = None,
+) -> list[str]:
+    """Filter timestamps to only include those within a time range.
+
+    Args:
+        timestamps: List of timestamp strings
+        start_time: Start of time range (timezone-aware datetime)
+        end_time: End of time range (timezone-aware datetime)
+        parse_format: Format string for parsing timestamps
+
+    Returns:
+        Filtered list of timestamps within the range
+    """
+    filtered = []
+    for ts in timestamps:
+        dt = parse_timestamp(ts, parse_format)
+        if dt is None:
+            continue
+
+        # Make timezone aware if needed
+        if dt.tzinfo is None:
+            dt = pytz.UTC.localize(dt)
+
+        if start_time <= dt <= end_time:
+            filtered.append(ts)
+
+    return filtered
+
+
+def find_common_timestamp(
+    timestamp_groups: dict[str, dict],
+    required_sources: set[str],
+    tolerance_minutes: int = 2,
+) -> tuple[str | None, dict | None]:
+    """Find most recent timestamp where all sources have data within tolerance.
+
+    Args:
+        timestamp_groups: Dict mapping timestamp -> {source_name: file_info}
+        required_sources: Set of source names that must all have data
+        tolerance_minutes: Maximum time difference allowed
+
+    Returns:
+        (common_timestamp, source_files) or (None, None)
+    """
+    # Parse all timestamps to datetime
+    timestamp_datetimes = {}
+    for ts_str in timestamp_groups.keys():
+        dt = parse_timestamp(ts_str)
+        if dt:
+            timestamp_datetimes[ts_str] = dt
+
+    if not timestamp_datetimes:
+        return None, None
+
+    # Sort by datetime (most recent first)
+    sorted_timestamps = sorted(
+        timestamp_datetimes.keys(),
+        key=lambda x: timestamp_datetimes[x],
+        reverse=True,
+    )
+
+    tolerance = timedelta(minutes=tolerance_minutes)
+
+    # For each timestamp, check if all sources have data within tolerance
+    for candidate_ts in sorted_timestamps:
+        candidate_dt = timestamp_datetimes[candidate_ts]
+        sources_in_window = {}
+
+        # Find sources with data in this time window
+        for ts_str, ts_dt in timestamp_datetimes.items():
+            if abs(ts_dt - candidate_dt) <= tolerance:
+                for source_name, file_info in timestamp_groups[ts_str].items():
+                    if source_name not in sources_in_window:
+                        sources_in_window[source_name] = (ts_str, file_info, ts_dt)
+                    else:
+                        # Keep the closer timestamp
+                        _, _, existing_dt = sources_in_window[source_name]
+                        if abs(ts_dt - candidate_dt) < abs(existing_dt - candidate_dt):
+                            sources_in_window[source_name] = (ts_str, file_info, ts_dt)
+
+        # Check if all required sources are present
+        if required_sources <= set(sources_in_window.keys()):
+            logger.debug(f"Found common time window around {candidate_ts}")
+            return candidate_ts, {
+                src: info for src, (_, info, _) in sources_in_window.items()
+            }
+
+    return None, None
+
+
+def extract_timestamp_from_hdf5_attrs(
+    what_attrs: dict,
+    date_key: str = "startdate",
+    time_key: str = "starttime",
+) -> str:
+    """Extract timestamp from HDF5 'what' attributes.
+
+    Args:
+        what_attrs: Dictionary of HDF5 'what' group attributes
+        date_key: Key for date attribute
+        time_key: Key for time attribute
+
+    Returns:
+        Timestamp string in YYYYMMDDHHMMSS format
+    """
+    date_str = what_attrs.get(date_key, "")
+    time_str = what_attrs.get(time_key, "")
+
+    # Handle bytes
+    if isinstance(date_str, bytes):
+        date_str = date_str.decode("utf-8")
+    if isinstance(time_str, bytes):
+        time_str = time_str.decode("utf-8")
+
+    # Combine and normalize
+    timestamp = date_str + time_str
+    return normalize_timestamp(timestamp, 14)
+
+
+def is_timestamp_in_cache(timestamp: str, cached_set: set[str]) -> bool:
+    """Check if a timestamp matches any entry in a cache set.
+
+    Handles different timestamp formats (with/without underscores, 12/14 digits).
+
+    Args:
+        timestamp: Timestamp string to check
+        cached_set: Set of cached timestamp strings
+
+    Returns:
+        True if timestamp matches any cached entry
+    """
+    if not cached_set:
+        return False
+
+    # Clean and normalize to different formats for comparison
+    ts_clean = timestamp.replace("_", "")
+    ts_12 = ts_clean[:12]  # YYYYMMDDHHMM
+    ts_14 = ts_12 + "00" if len(ts_clean) <= 12 else ts_clean[:14]
+
+    return (
+        timestamp in cached_set or
+        ts_clean in cached_set or
+        ts_12 in cached_set or
+        ts_14 in cached_set
+    )
+
+
+def timestamp_to_unix(timestamp: str, tz: str = "UTC") -> int:
+    """Convert timestamp string to Unix timestamp.
+
+    Args:
+        timestamp: Timestamp string (auto-detected format)
+        tz: Timezone name (default: UTC)
+
+    Returns:
+        Unix timestamp as integer
+    """
+    dt = parse_timestamp(timestamp)
+    if dt is None:
+        raise ValueError(f"Cannot parse timestamp: {timestamp}")
+
+    if dt.tzinfo is None:
+        dt = pytz.timezone(tz).localize(dt)
+
+    return int(dt.timestamp())

--- a/tests/test_imgw.py
+++ b/tests/test_imgw.py
@@ -91,41 +91,57 @@ class TestIMGWProducts:
 
 
 class TestIMGWTimestamps:
-    """Test IMGW timestamp generation"""
+    """Test timestamp generation using utility module (for IMGW YYYYMMDDHHMMSS format)"""
 
     def test_generate_timestamps_returns_list(self):
-        """Test that _generate_timestamps returns a list"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        """Test that generate_timestamp_candidates returns a list"""
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            generate_timestamp_candidates,
+        )
 
-        source = IMGWRadarSource()
-        timestamps = source._generate_timestamps(3)
+        timestamps = generate_timestamp_candidates(
+            count=3, interval_minutes=5, delay_minutes=10, format_str=TimestampFormat.FULL
+        )
         assert isinstance(timestamps, list)
 
     def test_generate_timestamps_returns_correct_count(self):
-        """Test that _generate_timestamps returns expected number of timestamps"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        """Test that generate_timestamp_candidates returns expected number of timestamps"""
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            generate_timestamp_candidates,
+        )
 
-        source = IMGWRadarSource()
-        timestamps = source._generate_timestamps(3)
-        # Should return at least count * 4 to account for missing data
+        timestamps = generate_timestamp_candidates(
+            count=3, interval_minutes=5, delay_minutes=10, format_str=TimestampFormat.FULL
+        )
+        # Should return at least count to account for missing data
         assert len(timestamps) >= 3
 
     def test_generate_timestamps_format_is_14_digits(self):
         """Test that timestamps are 14 digits (YYYYMMDDHHMMSS)"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            generate_timestamp_candidates,
+        )
 
-        source = IMGWRadarSource()
-        timestamps = source._generate_timestamps(3)
+        timestamps = generate_timestamp_candidates(
+            count=3, interval_minutes=5, delay_minutes=10, format_str=TimestampFormat.FULL
+        )
         for ts in timestamps:
             assert len(ts) == 14
             assert ts.isdigit()
 
     def test_generate_timestamps_are_5_minute_intervals(self):
         """Test that timestamps are at 5-minute intervals"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            generate_timestamp_candidates,
+        )
 
-        source = IMGWRadarSource()
-        timestamps = source._generate_timestamps(5)
+        timestamps = generate_timestamp_candidates(
+            count=5, interval_minutes=5, delay_minutes=10, format_str=TimestampFormat.FULL
+        )
         for ts in timestamps:
             # Extract minutes
             minutes = int(ts[10:12])
@@ -133,10 +149,14 @@ class TestIMGWTimestamps:
 
     def test_generate_timestamps_are_unique(self):
         """Test that generated timestamps are unique"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            generate_timestamp_candidates,
+        )
 
-        source = IMGWRadarSource()
-        timestamps = source._generate_timestamps(10)
+        timestamps = generate_timestamp_candidates(
+            count=10, interval_minutes=5, delay_minutes=10, format_str=TimestampFormat.FULL
+        )
         assert len(timestamps) == len(set(timestamps))
 
 
@@ -663,25 +683,31 @@ class TestIMGWPackageExport:
 
 
 class TestIMGWFilterTimestamps:
-    """Test IMGW timestamp filtering by time range"""
+    """Test timestamp filtering by time range using utility module"""
 
     def test_filter_timestamps_by_range_returns_list(self):
-        """Test that _filter_timestamps_by_range returns a list"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        """Test that filter_timestamps_by_range returns a list"""
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            filter_timestamps_by_range,
+        )
 
-        source = IMGWRadarSource()
         start = datetime(2025, 1, 27, 10, 0, tzinfo=pytz.UTC)
         end = datetime(2025, 1, 27, 12, 0, tzinfo=pytz.UTC)
         timestamps = ["20250127100000", "20250127110000", "20250127120000"]
 
-        result = source._filter_timestamps_by_range(timestamps, start, end)
+        result = filter_timestamps_by_range(
+            timestamps, start, end, parse_format=TimestampFormat.FULL
+        )
         assert isinstance(result, list)
 
     def test_filter_timestamps_by_range_filters_correctly(self):
         """Test that timestamps outside range are filtered out"""
-        from imeteo_radar.sources.imgw import IMGWRadarSource
+        from imeteo_radar.utils.timestamps import (
+            TimestampFormat,
+            filter_timestamps_by_range,
+        )
 
-        source = IMGWRadarSource()
         start = datetime(2025, 1, 27, 10, 0, tzinfo=pytz.UTC)
         end = datetime(2025, 1, 27, 11, 0, tzinfo=pytz.UTC)
         timestamps = [
@@ -692,7 +718,9 @@ class TestIMGWFilterTimestamps:
             "20250127120000",  # After range
         ]
 
-        result = source._filter_timestamps_by_range(timestamps, start, end)
+        result = filter_timestamps_by_range(
+            timestamps, start, end, parse_format=TimestampFormat.FULL
+        )
         assert "20250127090000" not in result
         assert "20250127100000" in result
         assert "20250127103000" in result

--- a/tests/test_outage_detection.py
+++ b/tests/test_outage_detection.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Tests for Source Outage Detection & Resilient Composite Generation
+
+Tests the outage detection logic and minimum core sources validation.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+import pytz
+
+from imeteo_radar.cli_composite import (
+    CORE_SOURCES,
+    DEFAULT_MAX_DATA_AGE_MINUTES,
+    DEFAULT_MIN_CORE_SOURCES,
+    OPTIONAL_SOURCES,
+    _count_available_core_sources,
+    _detect_source_outages,
+    _filter_available_sources,
+    _find_multiple_common_timestamps,
+)
+
+
+@pytest.fixture
+def mock_sources():
+    """Create mock source configurations."""
+    return {
+        "dwd": (MagicMock(), "dmax"),
+        "shmu": (MagicMock(), "zmax"),
+        "chmi": (MagicMock(), "maxz"),
+        "omsz": (MagicMock(), "cmax"),
+        "imgw": (MagicMock(), "cmax"),
+        "arso": (MagicMock(), "zm"),
+    }
+
+
+@pytest.fixture
+def recent_timestamp():
+    """Return a recent timestamp string (5 minutes ago)."""
+    now = datetime.now(pytz.UTC) - timedelta(minutes=5)
+    return now.strftime("%Y%m%d%H%M00")
+
+
+@pytest.fixture
+def stale_timestamp():
+    """Return a stale timestamp string (45 minutes ago)."""
+    now = datetime.now(pytz.UTC) - timedelta(minutes=45)
+    return now.strftime("%Y%m%d%H%M00")
+
+
+class TestSourceClassification:
+    """Tests for source classification constants."""
+
+    def test_core_sources_defined(self):
+        """Test that core sources are defined correctly."""
+        assert "dwd" in CORE_SOURCES
+        assert "shmu" in CORE_SOURCES
+        assert "chmi" in CORE_SOURCES
+        assert "omsz" in CORE_SOURCES
+        assert "imgw" in CORE_SOURCES
+        assert len(CORE_SOURCES) == 5
+
+    def test_optional_sources_defined(self):
+        """Test that optional sources are defined correctly."""
+        assert "arso" in OPTIONAL_SOURCES
+        assert len(OPTIONAL_SOURCES) == 1
+
+    def test_no_overlap_between_core_and_optional(self):
+        """Test that core and optional sources don't overlap."""
+        assert CORE_SOURCES.isdisjoint(OPTIONAL_SOURCES)
+
+
+class TestOutageDetection:
+    """Tests for _detect_source_outages function."""
+
+    def test_no_data_is_outage(self, mock_sources, recent_timestamp):
+        """Test that missing data is detected as outage."""
+        all_source_files = {
+            "dwd": [],  # No data
+            "shmu": [{"timestamp": recent_timestamp}],
+        }
+
+        availability, reasons = _detect_source_outages(
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            all_source_files,
+        )
+
+        assert availability["dwd"] is False
+        assert availability["shmu"] is True
+        assert "no data available" in reasons["dwd"]
+
+    def test_stale_data_is_outage(self, mock_sources, stale_timestamp):
+        """Test that stale data is detected as outage."""
+        all_source_files = {
+            "dwd": [{"timestamp": stale_timestamp}],
+        }
+
+        availability, reasons = _detect_source_outages(
+            {"dwd": mock_sources["dwd"]},
+            all_source_files,
+            max_data_age_minutes=30,
+        )
+
+        assert availability["dwd"] is False
+        assert "stale data" in reasons["dwd"]
+
+    def test_fresh_data_is_available(self, mock_sources, recent_timestamp):
+        """Test that fresh data is detected as available."""
+        all_source_files = {
+            "dwd": [{"timestamp": recent_timestamp}],
+        }
+
+        availability, reasons = _detect_source_outages(
+            {"dwd": mock_sources["dwd"]},
+            all_source_files,
+            max_data_age_minutes=30,
+        )
+
+        assert availability["dwd"] is True
+        assert "dwd" not in reasons
+
+    def test_multiple_timestamps_uses_newest(self, mock_sources, recent_timestamp, stale_timestamp):
+        """Test that newest timestamp is used for freshness check."""
+        all_source_files = {
+            "dwd": [
+                {"timestamp": stale_timestamp},
+                {"timestamp": recent_timestamp},
+            ],
+        }
+
+        availability, reasons = _detect_source_outages(
+            {"dwd": mock_sources["dwd"]},
+            all_source_files,
+        )
+
+        # Should be available because newest is fresh
+        assert availability["dwd"] is True
+
+    def test_missing_source_in_files_is_outage(self, mock_sources, recent_timestamp):
+        """Test that source not in all_source_files is outage."""
+        all_source_files = {
+            "shmu": [{"timestamp": recent_timestamp}],
+        }
+
+        availability, reasons = _detect_source_outages(
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            all_source_files,
+        )
+
+        assert availability["dwd"] is False
+        assert availability["shmu"] is True
+
+
+class TestCoreSourcesCounting:
+    """Tests for _count_available_core_sources function."""
+
+    def test_all_core_available(self):
+        """Test counting when all core sources are available."""
+        availability = {
+            "dwd": True,
+            "shmu": True,
+            "chmi": True,
+            "omsz": True,
+            "imgw": True,
+            "arso": True,
+        }
+
+        available, total = _count_available_core_sources(availability)
+
+        assert available == 5
+        assert total == 5
+
+    def test_some_core_unavailable(self):
+        """Test counting when some core sources are unavailable."""
+        availability = {
+            "dwd": True,
+            "shmu": True,
+            "chmi": False,
+            "omsz": True,
+            "imgw": False,
+            "arso": True,
+        }
+
+        available, total = _count_available_core_sources(availability)
+
+        assert available == 3
+        assert total == 5
+
+    def test_arso_not_counted_as_core(self):
+        """Test that ARSO (optional) is not counted as core."""
+        availability = {
+            "arso": False,  # Only ARSO, and it's down
+        }
+
+        available, total = _count_available_core_sources(availability)
+
+        assert available == 0
+        assert total == 0
+
+    def test_partial_sources_configuration(self):
+        """Test counting with partial source configuration."""
+        availability = {
+            "dwd": True,
+            "shmu": True,
+            "chmi": True,
+        }
+
+        available, total = _count_available_core_sources(availability)
+
+        assert available == 3
+        assert total == 3
+
+
+class TestSourceFiltering:
+    """Tests for _filter_available_sources function."""
+
+    def test_filters_unavailable_sources(self, mock_sources):
+        """Test that unavailable sources are filtered out."""
+        availability = {
+            "dwd": True,
+            "shmu": False,
+            "chmi": True,
+        }
+
+        filtered = _filter_available_sources(
+            {
+                "dwd": mock_sources["dwd"],
+                "shmu": mock_sources["shmu"],
+                "chmi": mock_sources["chmi"],
+            },
+            availability,
+        )
+
+        assert "dwd" in filtered
+        assert "shmu" not in filtered
+        assert "chmi" in filtered
+
+    def test_filters_unknown_sources(self, mock_sources):
+        """Test that sources not in availability dict are filtered out."""
+        availability = {
+            "dwd": True,
+        }
+
+        filtered = _filter_available_sources(
+            {
+                "dwd": mock_sources["dwd"],
+                "shmu": mock_sources["shmu"],  # Not in availability
+            },
+            availability,
+        )
+
+        assert "dwd" in filtered
+        assert "shmu" not in filtered
+
+
+class TestMultipleTimestampFinding:
+    """Tests for _find_multiple_common_timestamps function."""
+
+    def test_finds_multiple_timestamps(self, mock_sources):
+        """Test finding multiple common timestamps."""
+        timestamp_groups = {
+            "20260128120000": {"dwd": {"timestamp": "20260128120000"}, "shmu": {"timestamp": "20260128120000"}},
+            "20260128115500": {"dwd": {"timestamp": "20260128115500"}, "shmu": {"timestamp": "20260128115500"}},
+            "20260128115000": {"dwd": {"timestamp": "20260128115000"}, "shmu": {"timestamp": "20260128115000"}},
+        }
+
+        results = _find_multiple_common_timestamps(
+            timestamp_groups,
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            tolerance_minutes=2,
+            max_count=3,
+        )
+
+        assert len(results) == 3
+        # Should be sorted most recent first
+        assert results[0][0] == "20260128120000"
+        assert results[1][0] == "20260128115500"
+        assert results[2][0] == "20260128115000"
+
+    def test_respects_max_count(self, mock_sources):
+        """Test that max_count limits results."""
+        timestamp_groups = {
+            f"2026012812{i:02d}00": {"dwd": {"timestamp": f"2026012812{i:02d}00"}}
+            for i in range(10)
+        }
+
+        results = _find_multiple_common_timestamps(
+            timestamp_groups,
+            {"dwd": mock_sources["dwd"]},
+            max_count=3,
+        )
+
+        assert len(results) == 3
+
+    def test_respects_min_sources(self, mock_sources):
+        """Test that min_sources filters timestamps."""
+        timestamp_groups = {
+            "20260128120000": {"dwd": {"timestamp": "20260128120000"}, "shmu": {"timestamp": "20260128120000"}},
+            "20260128115500": {"dwd": {"timestamp": "20260128115500"}},  # Only DWD
+        }
+
+        results = _find_multiple_common_timestamps(
+            timestamp_groups,
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            min_sources=2,
+        )
+
+        assert len(results) == 1
+        assert results[0][0] == "20260128120000"
+
+    def test_finds_timestamps_within_tolerance(self, mock_sources, recent_timestamp):
+        """Test finding timestamps within tolerance window."""
+        # Create two timestamps 1 minute apart, both recent
+        now = datetime.now(pytz.UTC)
+        ts1 = now.strftime("%Y%m%d%H%M00")
+        ts2 = (now - timedelta(minutes=1)).strftime("%Y%m%d%H%M00")
+
+        timestamp_groups = {
+            ts1: {"dwd": {"timestamp": ts1}},
+            ts2: {"shmu": {"timestamp": ts2}},  # 1 min offset
+        }
+
+        results = _find_multiple_common_timestamps(
+            timestamp_groups,
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            tolerance_minutes=2,
+            min_sources=2,
+        )
+
+        # At least one result should be found
+        assert len(results) >= 1
+        # Both sources should be matched in the result (within tolerance)
+        assert "dwd" in results[0][1]
+        assert "shmu" in results[0][1]
+
+    def test_returns_empty_for_no_matches(self, mock_sources):
+        """Test returning empty list when no matches found."""
+        timestamp_groups = {
+            "20260128120000": {"dwd": {"timestamp": "20260128120000"}},
+            "20260128100000": {"shmu": {"timestamp": "20260128100000"}},  # 2 hours apart
+        }
+
+        results = _find_multiple_common_timestamps(
+            timestamp_groups,
+            {"dwd": mock_sources["dwd"], "shmu": mock_sources["shmu"]},
+            tolerance_minutes=2,
+            min_sources=2,
+        )
+
+        assert len(results) == 0
+
+
+class TestDefaultValues:
+    """Tests for default configuration values."""
+
+    def test_default_min_core_sources(self):
+        """Test default minimum core sources is 3."""
+        assert DEFAULT_MIN_CORE_SOURCES == 3
+
+    def test_default_max_data_age(self):
+        """Test default max data age is 30 minutes."""
+        assert DEFAULT_MAX_DATA_AGE_MINUTES == 30
+
+    def test_min_core_sources_allows_two_outages(self):
+        """Test that default min allows up to 2 core source outages."""
+        # With 5 core sources and min=3, we can have 2 outages
+        assert len(CORE_SOURCES) - DEFAULT_MIN_CORE_SOURCES == 2

--- a/tests/test_processed_cache.py
+++ b/tests/test_processed_cache.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""
+Tests for ProcessedDataCache
+
+Tests the dual-layer caching system for processed radar data.
+"""
+
+import json
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from imeteo_radar.utils.processed_cache import ProcessedDataCache
+
+
+@pytest.fixture
+def temp_cache_dir():
+    """Create a temporary directory for cache tests."""
+    temp_dir = tempfile.mkdtemp(prefix="radar_cache_test_")
+    yield Path(temp_dir)
+    # Cleanup
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def sample_radar_data():
+    """Create sample radar data for testing."""
+    return {
+        "data": np.random.rand(100, 100).astype(np.float32) * 50,
+        "extent": {
+            "wgs84": {
+                "west": 13.5,
+                "east": 17.5,
+                "south": 45.5,
+                "north": 49.5,
+            }
+        },
+        "metadata": {
+            "product": "zm",
+            "source": "arso",
+        },
+        "timestamp": "202501281005",
+        "lons": np.linspace(13.5, 17.5, 100),
+        "lats": np.linspace(45.5, 49.5, 100),
+    }
+
+
+class TestProcessedDataCache:
+    """Tests for ProcessedDataCache class."""
+
+    def test_cache_initialization(self, temp_cache_dir):
+        """Test cache initializes correctly."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=30,
+            s3_enabled=False,
+        )
+
+        assert cache.local_dir == temp_cache_dir
+        assert cache.ttl_minutes == 30
+        assert cache.s3_enabled is False
+        assert temp_cache_dir.exists()
+
+    def test_cache_put_get_roundtrip(self, temp_cache_dir, sample_radar_data):
+        """Test storing and retrieving data from cache."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store data
+        source = "arso"
+        timestamp = "202501281005"
+        product = "zm"
+
+        local_path = cache.put(source, timestamp, product, sample_radar_data)
+
+        assert local_path.exists()
+        assert local_path.suffix == ".npz"
+
+        # Retrieve data
+        retrieved = cache.get(source, timestamp, product)
+
+        assert retrieved is not None
+        assert "data" in retrieved
+        assert "extent" in retrieved
+        np.testing.assert_array_almost_equal(
+            retrieved["data"], sample_radar_data["data"], decimal=5
+        )
+        assert retrieved["extent"] == sample_radar_data["extent"]
+
+    def test_cache_miss_returns_none(self, temp_cache_dir):
+        """Test cache returns None for missing entries."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        result = cache.get("nonexistent", "202501281005", "zm")
+        assert result is None
+
+    def test_cache_exists(self, temp_cache_dir, sample_radar_data):
+        """Test exists() method for checking cache entries."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        source = "arso"
+        timestamp = "202501281005"
+        product = "zm"
+
+        # Should not exist initially
+        assert cache.exists(source, timestamp, product) is False
+
+        # Store data
+        cache.put(source, timestamp, product, sample_radar_data)
+
+        # Should exist now
+        assert cache.exists(source, timestamp, product) is True
+
+        # Different timestamp should not exist
+        assert cache.exists(source, "202501281010", product) is False
+
+    def test_cache_exists_respects_ttl(self, temp_cache_dir, sample_radar_data):
+        """Test exists() returns False for expired entries."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=0,  # Immediate expiration
+            s3_enabled=False,
+        )
+
+        # Store data
+        cache.put("arso", "202501281005", "zm", sample_radar_data, force=True)
+
+        # Wait for expiration
+        time.sleep(0.1)
+
+        # Should return False due to expiration
+        assert cache.exists("arso", "202501281005", "zm") is False
+
+    def test_put_skips_existing_entry(self, temp_cache_dir, sample_radar_data):
+        """Test put() skips saving if entry already exists."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        source = "arso"
+        timestamp = "202501281005"
+        product = "zm"
+
+        # First put should save
+        path1 = cache.put(source, timestamp, product, sample_radar_data)
+        assert path1 is not None
+        assert path1.exists()
+        mtime1 = path1.stat().st_mtime
+
+        # Wait a bit to ensure different mtime if file is rewritten
+        time.sleep(0.1)
+
+        # Second put should skip (return existing path, not rewrite)
+        path2 = cache.put(source, timestamp, product, sample_radar_data)
+        assert path2 == path1
+        mtime2 = path1.stat().st_mtime
+        assert mtime1 == mtime2  # File should not have been rewritten
+
+    def test_put_force_overwrites(self, temp_cache_dir, sample_radar_data):
+        """Test put() with force=True overwrites existing entry."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        source = "arso"
+        timestamp = "202501281005"
+        product = "zm"
+
+        # First put
+        cache.put(source, timestamp, product, sample_radar_data)
+        path = cache._get_local_path(source, timestamp, product)
+        mtime1 = path.stat().st_mtime
+
+        # Wait a bit
+        time.sleep(0.1)
+
+        # Second put with force should overwrite
+        cache.put(source, timestamp, product, sample_radar_data, force=True)
+        mtime2 = path.stat().st_mtime
+        assert mtime2 > mtime1  # File should have been rewritten
+
+    def test_cache_ttl_expiration(self, temp_cache_dir, sample_radar_data):
+        """Test cache entries expire after TTL."""
+        # Use very short TTL for testing
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=0,  # Immediate expiration
+            s3_enabled=False,
+        )
+
+        # Store data
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+
+        # Wait a moment to ensure expiration
+        time.sleep(0.1)
+
+        # Should return None due to expiration
+        result = cache.get("arso", "202501281005", "zm")
+        assert result is None
+
+    def test_get_available_timestamps(self, temp_cache_dir, sample_radar_data):
+        """Test getting available timestamps from cache."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store multiple timestamps
+        timestamps = ["202501281000", "202501281005", "202501281010"]
+        for ts in timestamps:
+            data = sample_radar_data.copy()
+            data["timestamp"] = ts
+            cache.put("arso", ts, "zm", data)
+
+        # Get available timestamps
+        available = cache.get_available_timestamps("arso", "zm")
+
+        assert len(available) == 3
+        # Should be sorted newest first
+        assert available[0] == "202501281010"
+        assert available[1] == "202501281005"
+        assert available[2] == "202501281000"
+
+    def test_get_available_timestamps_filters_by_product(
+        self, temp_cache_dir, sample_radar_data
+    ):
+        """Test that get_available_timestamps filters by product."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store different products at different timestamps
+        cache.put("shmu", "202501281005", "zmax", sample_radar_data)
+        cache.put("shmu", "202501281010", "rr1h", sample_radar_data)
+
+        # Filter by product
+        zmax_timestamps = cache.get_available_timestamps("shmu", "zmax")
+        rr1h_timestamps = cache.get_available_timestamps("shmu", "rr1h")
+        all_timestamps = cache.get_available_timestamps("shmu")
+
+        assert len(zmax_timestamps) == 1
+        assert len(rr1h_timestamps) == 1
+        # Without filter, we get all unique timestamps (2 different timestamps)
+        assert len(all_timestamps) == 2
+
+    def test_cleanup_expired(self, temp_cache_dir, sample_radar_data):
+        """Test cleanup of expired entries."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=0,  # Immediate expiration
+            s3_enabled=False,
+        )
+
+        # Store data
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+        cache.put("shmu", "202501281005", "zmax", sample_radar_data)
+
+        # Wait for expiration
+        time.sleep(0.1)
+
+        # Cleanup
+        removed = cache.cleanup_expired()
+
+        assert removed == 2
+
+        # Verify files are gone
+        arso_dir = temp_cache_dir / "arso"
+        shmu_dir = temp_cache_dir / "shmu"
+        assert len(list(arso_dir.glob("*.npz"))) == 0
+        assert len(list(shmu_dir.glob("*.npz"))) == 0
+
+    def test_clear_all(self, temp_cache_dir, sample_radar_data):
+        """Test clearing all cache entries."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store data for multiple sources
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+        cache.put("shmu", "202501281005", "zmax", sample_radar_data)
+
+        # Clear all
+        removed = cache.clear()
+
+        assert removed == 2
+
+        # Verify cache is empty
+        stats = cache.get_cache_stats()
+        assert stats["total_entries"] == 0
+
+    def test_clear_specific_source(self, temp_cache_dir, sample_radar_data):
+        """Test clearing cache for a specific source."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store data for multiple sources
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+        cache.put("shmu", "202501281005", "zmax", sample_radar_data)
+
+        # Clear only ARSO
+        removed = cache.clear("arso")
+
+        assert removed == 1
+
+        # Verify ARSO is empty but SHMU remains
+        arso_data = cache.get("arso", "202501281005", "zm")
+        shmu_data = cache.get("shmu", "202501281005", "zmax")
+
+        assert arso_data is None
+        assert shmu_data is not None
+
+    def test_get_cache_stats(self, temp_cache_dir, sample_radar_data):
+        """Test getting cache statistics."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store data
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+        cache.put("arso", "202501281010", "zm", sample_radar_data)
+        cache.put("shmu", "202501281005", "zmax", sample_radar_data)
+
+        stats = cache.get_cache_stats()
+
+        assert stats["total_entries"] == 3
+        assert stats["total_size_mb"] > 0
+        assert "arso" in stats["sources"]
+        assert "shmu" in stats["sources"]
+        assert stats["sources"]["arso"]["entries"] == 2
+        assert stats["sources"]["shmu"]["entries"] == 1
+
+    def test_npz_compression(self, temp_cache_dir, sample_radar_data):
+        """Test that NPZ files are compressed."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Create larger data for better compression test
+        large_data = sample_radar_data.copy()
+        large_data["data"] = np.random.rand(500, 500).astype(np.float32) * 50
+
+        local_path = cache.put("arso", "202501281005", "zm", large_data)
+
+        # Check file size is reasonable (compressed should be much smaller than raw)
+        file_size = local_path.stat().st_size
+        raw_size = large_data["data"].nbytes
+
+        # Compressed should be significantly smaller
+        assert file_size < raw_size
+
+    def test_metadata_json_structure(self, temp_cache_dir, sample_radar_data):
+        """Test that metadata JSON has correct structure."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        local_path = cache.put("arso", "202501281005", "zm", sample_radar_data)
+        metadata_path = local_path.with_suffix(".json")
+
+        assert metadata_path.exists()
+
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+
+        assert "source" in metadata
+        assert "timestamp" in metadata
+        assert "product" in metadata
+        assert "extent" in metadata
+        assert "dimensions" in metadata
+        assert "cached_at" in metadata
+        assert "cached_at_iso" in metadata
+
+        assert metadata["source"] == "arso"
+        assert metadata["timestamp"] == "202501281005"
+        assert metadata["product"] == "zm"
+
+    def test_timestamp_normalization(self, temp_cache_dir, sample_radar_data):
+        """Test that timestamps are normalized to 12 characters."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Store with 14-char timestamp
+        cache.put("arso", "20250128100500", "zm", sample_radar_data)
+
+        # Should be accessible with 12-char timestamp
+        result = cache.get("arso", "202501281005", "zm")
+        assert result is not None
+
+    def test_lons_lats_preservation(self, temp_cache_dir, sample_radar_data):
+        """Test that lons and lats arrays are preserved in coordinates dict."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Sample data has lons/lats at top level, but cache expects coordinates dict
+        # Update sample to match expected format
+        sample_with_coords = sample_radar_data.copy()
+        sample_with_coords["coordinates"] = {
+            "lons": sample_radar_data["lons"],
+            "lats": sample_radar_data["lats"],
+        }
+
+        cache.put("arso", "202501281005", "zm", sample_with_coords)
+        retrieved = cache.get("arso", "202501281005", "zm")
+
+        assert "coordinates" in retrieved
+        assert retrieved["coordinates"] is not None
+        assert "lons" in retrieved["coordinates"]
+        assert "lats" in retrieved["coordinates"]
+        np.testing.assert_array_almost_equal(
+            retrieved["coordinates"]["lons"],
+            sample_with_coords["coordinates"]["lons"],
+            decimal=5,
+        )
+        np.testing.assert_array_almost_equal(
+            retrieved["coordinates"]["lats"],
+            sample_with_coords["coordinates"]["lats"],
+            decimal=5,
+        )
+
+    def test_data_without_lons_lats(self, temp_cache_dir):
+        """Test caching data without optional lons/lats arrays."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Data without lons/lats
+        data = {
+            "data": np.random.rand(100, 100).astype(np.float32),
+            "extent": {
+                "wgs84": {"west": 13.5, "east": 17.5, "south": 45.5, "north": 49.5}
+            },
+            "metadata": {},
+            "timestamp": "202501281005",
+        }
+
+        cache.put("arso", "202501281005", "zm", data)
+        retrieved = cache.get("arso", "202501281005", "zm")
+
+        assert retrieved is not None
+        assert "data" in retrieved
+        # lons/lats should not be present
+        assert "lons" not in retrieved or retrieved.get("lons") is None
+        assert "lats" not in retrieved or retrieved.get("lats") is None
+
+
+class TestProcessedDataCacheS3:
+    """Tests for S3 integration (mocked)."""
+
+    def test_s3_disabled_by_default_when_not_configured(self, temp_cache_dir):
+        """Test S3 is disabled when environment variables are not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            cache = ProcessedDataCache(
+                local_dir=temp_cache_dir,
+                ttl_minutes=60,
+                s3_enabled=True,  # Request S3, but it won't be available
+            )
+
+            # S3 uploader should be None when not configured
+            uploader = cache._get_uploader()
+            assert uploader is None
+
+    def test_s3_upload_on_put(self, temp_cache_dir, sample_radar_data):
+        """Test that put() uploads to S3 when enabled."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=True,
+        )
+
+        # Mock the uploader
+        mock_uploader = MagicMock()
+        mock_uploader.bucket = "test-bucket"
+        cache._uploader = mock_uploader
+        cache._s3_initialized = True
+
+        cache.put("arso", "202501281005", "zm", sample_radar_data)
+
+        # Verify S3 upload was called
+        assert mock_uploader.s3_client.upload_file.call_count == 2  # NPZ + JSON
+
+    def test_s3_download_on_cache_miss(self, temp_cache_dir):
+        """Test that get() downloads from S3 on local cache miss."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=True,
+        )
+
+        # Mock the uploader with head_object raising error (file not found)
+        mock_uploader = MagicMock()
+        mock_uploader.bucket = "test-bucket"
+        mock_uploader.s3_client.head_object.side_effect = Exception("Not found")
+        cache._uploader = mock_uploader
+        cache._s3_initialized = True
+
+        result = cache.get("arso", "202501281005", "zm")
+
+        # Should return None since S3 doesn't have it either
+        assert result is None
+        # head_object should have been called to check S3
+        mock_uploader.s3_client.head_object.assert_called_once()
+
+
+class TestCacheIntegration:
+    """Integration tests for cache with composite workflow."""
+
+    def test_cache_enables_timestamp_matching(self, temp_cache_dir, sample_radar_data):
+        """Test that cache enables matching timestamps across runs."""
+        cache = ProcessedDataCache(
+            local_dir=temp_cache_dir,
+            ttl_minutes=60,
+            s3_enabled=False,
+        )
+
+        # Simulate Run 1: ARSO has 10:05, others have 10:00
+        # Cache ARSO 10:05
+        arso_data = sample_radar_data.copy()
+        arso_data["timestamp"] = "202501281005"
+        cache.put("arso", "202501281005", "zm", arso_data)
+
+        # Simulate Run 2: Check what timestamps are available
+        available = cache.get_available_timestamps("arso", "zm")
+        assert "202501281005" in available
+
+        # Now if SHMU catches up to 10:05, we can use cached ARSO
+        cached_arso = cache.get("arso", "202501281005", "zm")
+        assert cached_arso is not None
+        np.testing.assert_array_almost_equal(
+            cached_arso["data"], arso_data["data"], decimal=5
+        )


### PR DESCRIPTION
## Summary

- **Cache-aware downloading**: Skip downloads for timestamps already in cache (~90% reduction in redundant downloads)
- **Dual-layer processed data cache**: Local filesystem + S3/DO Spaces for persistence across pod restarts
- **S3 composite existence check**: Prevent regenerating composites that already exist in cloud storage
- **Skip reason tracking**: Enhanced logging shows exactly why timestamps are excluded

## Changes

### New Utility Modules
- `timestamps.py`: Timestamp generation, normalization, cache checking
- `hdf5_utils.py`: Common HDF5 processing functions  
- `parallel_download.py`: Parallel download execution
- `processed_cache.py`: Dual-layer cache implementation

### Source Refactoring
All 6 sources (DWD, SHMU, CHMI, OMSZ, ARSO, IMGW) refactored to support:
- `get_available_timestamps()` - query without downloading
- `download_timestamps()` - download specific timestamps
- ~150 lines of duplicate code removed

### Performance
| Metric | Before | After |
|--------|--------|-------|
| Downloads per run | ~48 files | ~6 files |
| Network usage | ~50 MB | ~6 MB |
| Run time | ~30 sec | ~10 sec |

## Test Plan

- [x] Run `imeteo-radar composite --disable-upload` twice
  - First run: Downloads all timestamps
  - Second run: Shows "X in cache, 1 to download" for each source
- [x] Verify skip reasons logged correctly
- [x] 30-minute monitoring test completed (8 runs, 6 composites generated)
- [x] Unit tests pass (149 passed)

## Documentation

- Updated architecture.md with mermaid diagrams
- Updated cli-reference.md with cache behavior
- Updated monitoring.md with troubleshooting guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)