### PR TITLE
feat: Auto-generate extent and coverage masks on first run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.6.0"
+version = "2.7.0"
 description = "Weather radar data processor for DWD, SHMU, CHMI, OMSZ, ARSO, and IMGW weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/run_composite_loop.sh
+++ b/scripts/run_composite_loop.sh
@@ -31,10 +31,10 @@ while true; do
 
     # Run composite with backload
     imeteo-radar composite \
-        --formats png \
-        --resolutions full \
+        --formats png,avif \
+        --resolutions full,1000 \
+        --update-extent \
         --avif-quality 50 \
-        --no-individual \
         --output ./outputs/composite \
         2>&1
 


### PR DESCRIPTION
## Summary
- **Auto-generate extent**: New `_auto_generate_extent()` downloads radar data to create `extent_index.json` when missing during mask generation
- **Always check masks**: Remove `processed_count > 0` guard — masks are checked every composite run, not just when new data is processed
- **Force individual masks for composite**: When composite mask is missing, individual masks are always generated (needed for merging)
- **Fallback dimensions from transform cache**: New `_get_dimensions_from_transform_cache()` reads grid `.npz` files when no PNGs exist yet
- **Update composite loop**: Enable `png,avif` formats, `full,1000` resolutions, add `--update-extent`, remove `--no-individual`
- **Version bump**: 2.6.0 → 2.7.0

## Test plan
- [ ] Run composite with empty outputs dir — verify extent auto-generates
- [ ] Run composite with no existing PNGs — verify transform cache fallback works
- [ ] Run composite with `--no-individual` — verify individual masks still generate when composite mask is missing
- [ ] Verify masks align pixel-perfectly with data PNGs
- [ ] Run Docker loop with updated script defaults