### PR TITLE
fix: Prevent DWD timeout from crashing composite process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2026-03-02
+
+### Fixed
+- **DWD timeout no longer crashes entire composite process** — Added try/except around
+  `_get_available_timestamps_from_server()` in `dwd.py` so Strategy 2 (timestamp probing)
+  is reached when the directory listing fails after retries
+- **Per-source failures no longer terminate composite generation** — Added try/except around
+  `source.get_available_timestamps()` in `cli_composite.py` so remaining sources continue
+  processing when one source is unreachable. Existing outage detection and `min_core_sources`
+  logic now properly activates.
+
+### Added
+- **DWD connectivity diagnostics** — Logs DNS resolution, TCP connection, and TLS handshake
+  timing before each DWD directory listing request, providing visibility into persistent
+  connection failures in production
+
 ## [2.6.0] - 2026-02-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.7.0"
+version = "2.8.1"
 description = "Weather radar data processor for DWD, SHMU, CHMI, OMSZ, ARSO, and IMGW weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -563,10 +563,17 @@ def _process_latest(args, sources, exporter, export_config, output_dir, uploader
             cached_ts_set = set(cache.get_available_timestamps(source_name, product))
 
         # Get available timestamps from provider (without downloading yet)
-        available_timestamps = source.get_available_timestamps(
-            count=reprocess_count + 2,
-            products=[product],
-        )
+        try:
+            available_timestamps = source.get_available_timestamps(
+                count=reprocess_count + 2,
+                products=[product],
+            )
+        except Exception as e:
+            logger.warning(
+                f"{source_name.upper()}: Failed to get timestamps: {e}"
+            )
+            all_source_files[source_name] = []
+            continue
 
         if not available_timestamps:
             logger.warning(


### PR DESCRIPTION
## Summary

- DWD connection timeout was crashing the entire composite process instead of gracefully degrading
- Two missing try/except blocks prevented existing resilience logic (Strategy 2 fallback, outage detection, `min_core_sources=3`) from ever being reached
- Added DNS/TCP/TLS diagnostic logging to help debug persistent DWD connectivity issues in production

## Changes

- `src/imeteo_radar/sources/dwd.py` — Wrap Strategy 1 call in try/except so Strategy 2 is reached on failure; add connection diagnostics
- `src/imeteo_radar/cli_composite.py` — Wrap per-source `get_available_timestamps()` in try/except so one source failure doesn't crash the loop
- `pyproject.toml` — Bump version to 2.8.1
- `CHANGELOG.md` — Document fixes

## Test plan

- [x] Reproduced crash locally: blocked DWD host in Docker, composite crashed with traceback
- [x] Verified fix: blocked DWD host, composite gracefully skipped DWD and produced output from remaining sources
- [x] Verified normal operation: DWD reachable, diagnostics logged timing, composite produced full output
- [x] Verified diagnostic output: DNS resolution IP, TCP connect time, TLS handshake version and time all logged