### PR TITLE
chore: Optimize CI pipeline — drop arm64, eliminate duplicate builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,18 +2,17 @@ name: Docker Image CI/CD
 
 on:
   push:
-    branches: [ "main" ]
     tags:
-      - 'v*'  # Trigger on version tags like v1.0.0
+      - 'v*'
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:
 
 env:
   DOCKERHUB_REPO: lfranko/imeteo-radar
 
 jobs:
-  # Job 1: Validate PR builds (fast, single platform)
+  # Validate PR builds (no push)
   validate:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -25,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build for validation
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -34,27 +33,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: PR Build Summary
-        run: |
-          echo "## Docker Build Validated ✅" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Docker image built successfully for PR validation." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Note:** Image was not pushed to DockerHub (PR builds are for validation only)." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Once merged to main, the image will be published to:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.DOCKERHUB_REPO }}:latest\`" >> $GITHUB_STEP_SUMMARY
-
-  # Job 2: Build and push for main/tags (multi-platform)
+  # Build and push on version tags (single build per release)
   build-and-push:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -65,8 +50,7 @@ jobs:
         with:
           images: ${{ env.DOCKERHUB_REPO }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value={{branch}}-{{sha}},enable={{is_default_branch}}
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
@@ -76,41 +60,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push multi-platform image
-        uses: docker/build-push-action@v5
+      - name: Build and push image
+        uses: docker/build-push-action@v6
         id: build
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache
-          cache-to: type=registry,ref=${{ env.DOCKERHUB_REPO }}:buildcache,mode=max
-
-      - name: Print image digest
-        run: |
-          echo "Image digest: ${{ steps.build.outputs.digest }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate build summary
         run: |
-          echo "## Docker Image Published! 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Repository:** \`${{ env.DOCKERHUB_REPO }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
+          echo "**Platform:** linux/amd64" >> $GITHUB_STEP_SUMMARY
+          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pull the image:**" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.DOCKERHUB_REPO }}:latest" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**DockerHub:** https://hub.docker.com/r/${{ env.DOCKERHUB_REPO }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Drop arm64 cross-compilation via QEMU (not deployed to arm64 nodes)
- Trigger `build-and-push` only on tag push, eliminating the duplicate build that ran on main push with identical content
- Switch from registry-based cache to GHA cache (faster for single-platform)
- Bump `build-push-action` from v5 to v6
- Drop unused `main-{sha}` tag

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Runs per release | 3 (PR + main + tag) | 2 (PR + tag) |
| `build-and-push` per release | 2 (redundant) | 1 |
| Build time | ~13 min (QEMU arm64) | ~4-5 min (amd64 only) |
| Total CI per release | ~30 min | ~9 min |

## Test plan

- [x] Verify PR validation job still triggers on pull_request
- [ ] Verify build-and-push triggers on next tag push
- [ ] Verify GHA cache works on second build