### PR TITLE
fix: Reduce memory usage and redundant downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.8.1"
+version = "2.8.3"
 description = "Weather radar data processor for DWD, SHMU, CHMI, OMSZ, ARSO, and IMGW weather radar data"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/test-memory-optimization.sh
+++ b/scripts/test-memory-optimization.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Simulates K8s CronJobs locally for 1 hour to verify memory optimization changes.
+# Runs the 3 production CronJob commands every 5 minutes and logs peak RSS.
+#
+# Usage: ./scripts/test-memory-optimization.sh
+# Requires: docker, .env with DO Spaces credentials
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+IMAGE_NAME="imeteo-radar:mem-test"
+LOG_DIR="$PROJECT_DIR/outputs/mem-test-logs"
+INTERVAL_SEC=300  # 5 minutes
+ITERATIONS=12     # 12 × 5 min = 1 hour
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log() { echo -e "${CYAN}[$(date '+%H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%H:%M:%S')] WARN:${NC} $1"; }
+
+# Load .env
+if [ -f "$PROJECT_DIR/.env" ]; then
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+    log "Loaded .env"
+else
+    warn "No .env found — S3 uploads will be disabled"
+fi
+
+# Build image
+log "Building Docker image: $IMAGE_NAME"
+docker build -t "$IMAGE_NAME" "$PROJECT_DIR"
+
+# Prepare log directory
+mkdir -p "$LOG_DIR"
+log "Logs: $LOG_DIR"
+
+# Common docker run args
+DOCKER_ENV=(
+    -e "TZ=Europe/Berlin"
+    -e "DIGITALOCEAN_SPACES_KEY=${DIGITALOCEAN_SPACES_KEY:-}"
+    -e "DIGITALOCEAN_SPACES_SECRET=${DIGITALOCEAN_SPACES_SECRET:-}"
+    -e "DIGITALOCEAN_SPACES_ENDPOINT=${DIGITALOCEAN_SPACES_ENDPOINT:-}"
+    -e "DIGITALOCEAN_SPACES_REGION=${DIGITALOCEAN_SPACES_REGION:-}"
+    -e "DIGITALOCEAN_SPACES_BUCKET=${DIGITALOCEAN_SPACES_BUCKET:-}"
+    -e "DIGITALOCEAN_SPACES_URL=${DIGITALOCEAN_SPACES_URL:-}"
+    -e "TRACEMALLOC=1"
+)
+
+# Shared volume for data/cache across runs (simulates K8s PVC)
+VOLUME_ARGS=(
+    -v "$PROJECT_DIR/outputs/mem-test-data:/tmp/iradar"
+    -v "$PROJECT_DIR/outputs/mem-test-cache:/tmp/iradar-data"
+)
+
+mkdir -p "$PROJECT_DIR/outputs/mem-test-data" "$PROJECT_DIR/outputs/mem-test-cache"
+
+# Run a single CronJob command and capture peak RSS
+run_job() {
+    local job_name="$1"
+    shift
+    local log_file="$LOG_DIR/${job_name}_$(date '+%H%M%S').log"
+
+    log "${GREEN}Starting:${NC} $job_name"
+    local start_time=$SECONDS
+
+    # Run with memory tracking via /usr/bin/time if available
+    docker run --rm \
+        --name "memtest-${job_name}-$$" \
+        --memory=3g \
+        "${DOCKER_ENV[@]}" \
+        "${VOLUME_ARGS[@]}" \
+        "$IMAGE_NAME" \
+        "$@" \
+        > "$log_file" 2>&1 || true
+
+    local elapsed=$(( SECONDS - start_time ))
+    local exit_msg="done in ${elapsed}s"
+
+    # Extract tracemalloc peak from log if present
+    local peak=$(grep -i "tracemalloc\|peak memory\|Peak:" "$log_file" 2>/dev/null | tail -1 || echo "")
+    if [ -n "$peak" ]; then
+        exit_msg="$exit_msg | $peak"
+    fi
+
+    log "${GREEN}Finished:${NC} $job_name ($exit_msg) -> $log_file"
+}
+
+# Summary header
+echo ""
+echo "============================================="
+echo "  Memory Optimization Verification Test"
+echo "  Image:      $IMAGE_NAME"
+echo "  Iterations: $ITERATIONS (every ${INTERVAL_SEC}s = 1 hour)"
+echo "  Jobs:       dwd-fetch, chmi-fetch, composite"
+echo "============================================="
+echo ""
+
+# Main loop
+for i in $(seq 1 $ITERATIONS); do
+    log "=== Iteration $i/$ITERATIONS ==="
+
+    # Run CronJob 1: DWD fetch (backload 1 hour)
+    run_job "dwd-fetch" \
+        imeteo-radar fetch --source dwd --backload --hours 1 \
+        --output /tmp/iradar/germany
+
+    # Run CronJob 2: CHMI fetch (backload 1 hour)
+    run_job "chmi-fetch" \
+        imeteo-radar fetch --source chmi --backload --hours 1 \
+        --output /tmp/iradar/czechia
+
+    # Run CronJob 3: Composite
+    run_job "composite" \
+        imeteo-radar composite --no-individual \
+        --formats png,avif --resolutions full,2000 \
+        --avif-speed 8 --avif-quality 50 \
+        --output /tmp/iradar/composite
+
+    if [ "$i" -lt "$ITERATIONS" ]; then
+        log "Sleeping ${INTERVAL_SEC}s until next iteration..."
+        sleep "$INTERVAL_SEC"
+    fi
+done
+
+echo ""
+log "=== Test complete ==="
+log "Logs directory: $LOG_DIR"
+
+# Print summary of peak memory from all logs
+echo ""
+echo "=== Memory peaks (from tracemalloc) ==="
+grep -rh "tracemalloc\|peak memory\|Peak:" "$LOG_DIR"/ 2>/dev/null | sort || echo "(no tracemalloc output found)"
+
+echo ""
+echo "=== Error summary ==="
+error_count=$(grep -rlc "ERROR\|Traceback\|OOM" "$LOG_DIR"/ 2>/dev/null | wc -l || echo 0)
+echo "Files with errors: $error_count"
+if [ "$error_count" -gt 0 ]; then
+    grep -rh "ERROR\|Traceback" "$LOG_DIR"/ 2>/dev/null | head -20
+fi

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -626,7 +626,7 @@ def fetch_command(args) -> int:
     # Import here to avoid circular imports and speed up CLI startup
     try:
         from .config.sources import get_source_config, get_source_instance
-        from .processing.exporter import ExportConfig, MultiFormatExporter
+        from .processing.exporter import MultiFormatExporter
         from .utils.spaces_uploader import SpacesUploader, is_spaces_configured
 
         # Initialize source using centralized registry
@@ -698,6 +698,7 @@ def fetch_command(args) -> int:
         if args.backload:
             # Handle backload
             start, end = parse_time_range(args.from_time, args.to_time, args.hours)
+            from .utils.cli_helpers import output_exists
 
             logger.info(
                 f"Backload period: {start.strftime('%Y-%m-%d %H:%M')} to {end.strftime('%Y-%m-%d %H:%M')}"
@@ -712,22 +713,56 @@ def fetch_command(args) -> int:
 
             logger.info(f"Downloading up to {intervals} timestamps...")
 
-            # Download data (don't use LATEST for backload)
-            if args.source == "dwd":
-                files = source.download_latest(
-                    count=intervals,
-                    products=[product],
-                    use_latest=False,
-                    start_time=start,
-                    end_time=end,
-                )
-            else:  # SHMU
-                files = source.download_latest(
-                    count=intervals, products=[product], start_time=start, end_time=end
+            # Get available timestamps first, then filter out already-processed ones
+            available_timestamps = source.get_available_timestamps(
+                count=intervals,
+                products=[product],
+                start_time=start,
+                end_time=end,
+            )
+
+            if not available_timestamps:
+                logger.error("No data available for the specified period")
+                return 1
+
+            # Filter out timestamps whose output already exists (local or S3)
+            timestamps_to_download = []
+            skipped_existing = 0
+            for ts in available_timestamps:
+                try:
+                    dt = parse_timestamp_to_datetime(ts, args.source)
+                except (ValueError, IndexError):
+                    logger.debug(f"Skipping malformed timestamp: {ts}")
+                    continue
+                unix_timestamp = int(dt.timestamp())
+                filename = f"{unix_timestamp}.png"
+                output_path = output_dir / filename
+
+                if output_exists(
+                    output_path,
+                    args.source,
+                    filename,
+                    uploader if upload_enabled else None,
+                ):
+                    skipped_existing += 1
+                else:
+                    timestamps_to_download.append(ts)
+
+            if skipped_existing > 0:
+                logger.info(
+                    f"Skipped {skipped_existing} already-processed timestamps, "
+                    f"{len(timestamps_to_download)} to download"
                 )
 
+            if not timestamps_to_download:
+                logger.info("All timestamps already processed, nothing to do")
+                return 0
+
+            # Download only missing timestamps
+            files = source.download_timestamps(timestamps_to_download, [product])
+
             if not files:
-                logger.error("No data available for the specified period")
+                logger.error("Failed to download any files")
                 return 1
 
             logger.info(f"Downloaded {len(files)} files", extra={"count": len(files)})
@@ -770,17 +805,15 @@ def fetch_command(args) -> int:
 
                     # Upload all variants to DigitalOcean Spaces if enabled
                     if upload_enabled and uploader:
-                        for variant_name, (variant_path, _) in variants.items():
+                        for _variant_name, (variant_path, _) in variants.items():
                             uploader.upload_file(
                                 variant_path, args.source, variant_path.name
                             )
 
-                    # Clean up matplotlib and numpy memory after each file
+                    # Free large arrays and collect garbage after each file
                     import gc
 
-                    import matplotlib.pyplot as plt
-
-                    plt.close("all")
+                    del radar_data
                     gc.collect()
 
                 except Exception as e:
@@ -803,8 +836,6 @@ def fetch_command(args) -> int:
             # Fetch multiple recent timestamps with cache awareness
             # This handles irregular provider uploads by checking multiple timestamps
             import gc
-
-            import matplotlib.pyplot as plt
 
             from .utils.cli_helpers import init_cache_from_args, output_exists
             from .utils.timestamps import is_timestamp_in_cache
@@ -910,13 +941,12 @@ def fetch_command(args) -> int:
 
                     # Upload all variants to DigitalOcean Spaces if enabled
                     if upload_enabled and uploader:
-                        for variant_name, (variant_path, _) in variants.items():
+                        for _variant_name, (variant_path, _) in variants.items():
                             uploader.upload_file(
                                 variant_path, args.source, variant_path.name
                             )
 
                     # Clean up memory
-                    plt.close("all")
                     del radar_data
                     gc.collect()
 
@@ -969,13 +999,12 @@ def fetch_command(args) -> int:
                     processed_count += 1
 
                     if upload_enabled and uploader:
-                        for variant_name, (variant_path, _) in variants.items():
+                        for _variant_name, (variant_path, _) in variants.items():
                             uploader.upload_file(
                                 variant_path, args.source, variant_path.name
                             )
 
                     # Clean up memory
-                    plt.close("all")
                     del radar_data
                     gc.collect()
 

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -511,10 +511,13 @@ def _process_latest(args, sources, exporter, export_config, output_dir, uploader
     ensure_mask_exists("composite")
 
     # Ensure transform grids are synced with S3 (download missing, upload local-only)
-    from .processing.transform_cache import TransformCache
+    # Skip when --no-individual: transform cache is only used for individual source exports,
+    # the compositor uses rasterio.warp.reproject() directly
+    if not args.no_individual:
+        from .processing.transform_cache import TransformCache
 
-    transform_cache = TransformCache()
-    transform_cache.sync_with_s3()
+        transform_cache = TransformCache()
+        transform_cache.sync_with_s3()
 
     # ========== STEP 1: DOWNLOAD DATA FROM ALL SOURCES ==========
     logger.info("Downloading data from all sources...")
@@ -1008,7 +1011,6 @@ def _process_latest(args, sources, exporter, export_config, output_dir, uploader
             processed_count += 1
             last_composite = {
                 "extent": {"wgs84": composite["extent"]},
-                "data": composite["data"],
             }
 
             compositor.clear_cache()
@@ -1242,8 +1244,6 @@ def _export_single_source(
         args: CLI arguments
         uploader: Optional SpacesUploader instance for uploading to DO Spaces
     """
-    import json
-
     # Get output directory (sibling of composite dir)
     composite_output = Path(args.output)
     output_dir = _get_individual_source_dir(source_name, composite_output)
@@ -1755,7 +1755,6 @@ def _process_backload(args, sources, exporter, export_config, output_dir, upload
             processed_count += 1
             last_composite = {
                 "extent": {"wgs84": composite["extent"]},
-                "data": composite["data"],
             }
 
             # Cleanup

--- a/src/imeteo_radar/core/base.py
+++ b/src/imeteo_radar/core/base.py
@@ -5,6 +5,7 @@ Base classes for radar data sources
 
 import os
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any
 
 import numpy as np
@@ -42,6 +43,8 @@ class RadarSource(ABC):
         self,
         count: int = 8,
         products: list[str] = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
     ) -> list[str]:
         """Get list of available timestamps from provider WITHOUT downloading.
 
@@ -51,6 +54,8 @@ class RadarSource(ABC):
         Args:
             count: Maximum number of timestamps to return
             products: List of products to check
+            start_time: Optional start time for filtering
+            end_time: Optional end time for filtering
 
         Returns:
             List of timestamp strings (e.g., ["20260128135000", "20260128134500"])

--- a/src/imeteo_radar/processing/exporter.py
+++ b/src/imeteo_radar/processing/exporter.py
@@ -6,6 +6,7 @@ Exports radar data as transparent PNG and AVIF overlays with consistent colorsca
 Supports multiple resolutions and formats per timestamp.
 """
 
+import gc
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -510,19 +511,25 @@ class MultiFormatExporter:
                 data, cmap_name, transparent_background
             )
 
+            # Extract values needed for metadata, then free the large float32 array (~96 MB)
+            data_shape = data.shape
+            data_range = [float(np.nanmin(data)), float(np.nanmax(data))]
+            del data
+            gc.collect()
+
             # Get WGS84 bounds for scaling calculations
             wgs84_extent = output_extent.get("wgs84", extent.get("wgs84", {}))
             source_name = radar_data.get("metadata", {}).get("source", "").lower()
 
             # Build base metadata
             base_metadata = {
-                "dimensions": data.shape,
+                "dimensions": data_shape,
                 "extent": wgs84_extent,
                 "extent_reference": "config/extent_index.json",
                 "source": source_name or "unknown",
                 "colormap": cmap_name,
                 "units": lut_info["units"],
-                "data_range": [float(np.nanmin(data)), float(np.nanmax(data))],
+                "data_range": data_range,
                 "valid_pixels": int(np.sum(valid_mask)),
                 "used_cached_transform": used_cache,
                 "transparent": transparent_background,
@@ -563,7 +570,7 @@ class MultiFormatExporter:
             # Export scaled variants
             for target_res in config.resolutions_m:
                 scaled_dims = self._calculate_scaled_dimensions(
-                    data.shape, wgs84_extent, target_res, source_name
+                    data_shape, wgs84_extent, target_res, source_name
                 )
                 scaled_rgba = self._resize_rgba(rgba_data, scaled_dims)
 
@@ -595,6 +602,10 @@ class MultiFormatExporter:
                     }
                     variants[variant_name] = (output_path, metadata)
                     logger.info(f"Saved: {output_path}")
+
+            # Free full-res RGBA array after all variants are saved (~96 MB)
+            del rgba_data
+            gc.collect()
 
             return variants
 


### PR DESCRIPTION
## Summary

- **Free large arrays early** in exporter: `data` float32 (~96 MB) freed after RGBA render, `rgba_data` (~96 MB) freed after resize loop
- **Remove composite data leak**: `last_composite` no longer holds the 96 MB data array between iterations
- **Skip transform cache sync** when `--no-individual` (saves S3 I/O, not needed for composite-only runs)
- **Deduplicate backload downloads**: check `output_exists()` before downloading — reduces DWD requests from ~144/hour to ~12/hour
- **Remove unnecessary matplotlib import** in fetch loop (~20-30 MB one-time savings)
- **Fix ruff warnings**: unused imports (`ExportConfig`, `json`), unused loop variables, base class signature alignment

**Expected peak RSS reduction: ~200-300 MB** (from 2.4 GB baseline).

## Verification

1-hour Docker test (12 iterations × 3 CronJobs = 36 runs):

| Metric | Result |
|--------|--------|
| Iterations | **12/12 passed** |
| Errors | **0** |
| DWD fetch | 1-2s per run, **0 downloads** (all deduped) |
| CHMI fetch | 3-4s per run, **1 download** per run (11 skipped) |
| Composite | 14-21s per run, 4 variants (PNG+AVIF × full+2000m) |

## Test plan

- [x] `ruff check` passes on all modified files
- [x] Unit tests pass (66/67, 1 pre-existing IMGW failure)
- [x] 1-hour Docker soak test: 12/12 iterations, 0 errors
- [x] DWD backload dedup verified: 0 redundant downloads
- [x] CHMI backload dedup verified: only new timestamps downloaded
- [x] Composite generates correct output (4 variants, 6 sources)
- [ ] Verify peak RSS < 2.2 GB with tracemalloc in K8s