### PR TITLE
fix: Add connectivity pre-check and execution timeout

### DIFF
--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -8,6 +8,7 @@ Focused on DWD dmax product with simple fetch command.
 import argparse
 import sys
 import time
+from contextlib import nullcontext as _nullcontext
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -81,6 +82,13 @@ def create_parser() -> argparse.ArgumentParser:
         "--disable-upload",
         action="store_true",
         help="Disable upload to DigitalOcean Spaces (for local development only)",
+    )
+
+    fetch_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Max execution time in seconds (default: 180). Exit code 2 on timeout.",
     )
 
     # Reprocess count for non-backload mode
@@ -250,6 +258,12 @@ def create_parser() -> argparse.ArgumentParser:
         default=6,
         help="Number of recent timestamps to (re)process (default: 6 = 30 min). "
         "Allows automatic reprocessing when providers backload data after outages.",
+    )
+    composite_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=180,
+        help="Max execution time in seconds (default: 180). Exit code 2 on timeout.",
     )
     composite_parser.add_argument(
         "--disable-upload",
@@ -636,6 +650,13 @@ def fetch_command(args) -> int:
             return 1
 
         source = get_source_instance(args.source)
+
+        try:
+            source.check_connectivity()
+        except ConnectionError as e:
+            logger.error(f"{args.source.upper()} server unreachable: {e}")
+            return 1
+
         product = source_config["product"]
         country_dir = source_config["country"]
 
@@ -1065,26 +1086,36 @@ def main():
         log_file=log_file,
     )
 
+    from .core.retry import ExecutionTimeout
+
+    timeout = getattr(args, "timeout", 0)
+
     try:
-        if args.command == "fetch":
-            return fetch_command(args)
-        elif args.command == "extent":
-            return extent_command(args)
-        elif args.command == "composite":
-            return composite_command(args)
-        elif args.command == "coverage-mask":
-            return coverage_mask_command(args)
-        elif args.command == "cache":
-            return cache_command(args)
-        elif args.command == "transform-cache":
-            return transform_cache_command(args)
-        else:
-            logger.error(f"Unknown command: {args.command}")
-            return 1
+        with ExecutionTimeout(timeout) if timeout > 0 else _nullcontext():
+            if args.command == "fetch":
+                return fetch_command(args)
+            elif args.command == "extent":
+                return extent_command(args)
+            elif args.command == "composite":
+                return composite_command(args)
+            elif args.command == "coverage-mask":
+                return coverage_mask_command(args)
+            elif args.command == "cache":
+                return cache_command(args)
+            elif args.command == "transform-cache":
+                return transform_cache_command(args)
+            else:
+                logger.error(f"Unknown command: {args.command}")
+                return 1
 
     except KeyboardInterrupt:
         logger.warning("Operation cancelled by user")
         return 1
+    except SystemExit as e:
+        if e.code == 2 and timeout > 0:
+            logger.error(f"Execution timeout after {timeout}s")
+            return 2
+        raise
     except Exception as e:
         logger.error(f"Error: {e}")
         return 1

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -560,6 +560,15 @@ def _process_latest(args, sources, exporter, export_config, output_dir, uploader
 
     # Download fresh data from each source, SKIPPING cached timestamps
     for source_name, (source, product) in sources.items():
+        try:
+            source.check_connectivity()
+        except ConnectionError as e:
+            logger.warning(
+                f"{source_name.upper()}: Server unreachable, skipping: {e}"
+            )
+            all_source_files[source_name] = []
+            continue
+
         # Get cached timestamps for this source
         cached_ts_set = set()
         if cache:

--- a/src/imeteo_radar/core/base.py
+++ b/src/imeteo_radar/core/base.py
@@ -7,10 +7,12 @@ import os
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 
 from .logging import get_logger
+from .retry import tcp_probe
 
 logger = get_logger(__name__)
 
@@ -22,6 +24,19 @@ class RadarSource(ABC):
         self.name = name
         self.cache_dir = f"processed/{name}_data"
         self.temp_files: dict[str, str] = {}  # Track temporary files for cleanup
+
+    def check_connectivity(self, timeout: float = 5.0) -> None:
+        """TCP probe the source's host. Raises ConnectionError if unreachable."""
+        url = getattr(self, "base_url", None) or getattr(self, "BASE_URL", None)
+        if url is None:
+            return
+        host = urlparse(url).hostname
+        if host:
+            tcp_probe(host, 443, timeout)
+            logger.debug(
+                f"{self.name.upper()} connectivity OK ({host}:443)",
+                extra={"source": self.name},
+            )
 
     @abstractmethod
     def download_latest(

--- a/src/imeteo_radar/core/retry.py
+++ b/src/imeteo_radar/core/retry.py
@@ -7,9 +7,48 @@ backoff strategies and callback hooks.
 """
 
 import random
+import signal
+import socket
+import sys
 import time
 from functools import wraps
 from collections.abc import Callable
+
+
+def tcp_probe(host: str, port: int = 443, timeout: float = 5.0) -> None:
+    """Fast TCP reachability check. Raises ConnectionError on failure."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+    except OSError as e:
+        raise ConnectionError(
+            f"{host}:{port} unreachable ({timeout}s): {e}"
+        ) from e
+
+
+class ExecutionTimeout:
+    """SIGALRM-based wall-clock deadline. Unix-only. Raises SystemExit(2) on timeout."""
+
+    def __init__(self, seconds: int, message: str = "Execution timeout"):
+        self.seconds = seconds
+        self.message = message
+        self._old_handler = signal.SIG_DFL
+
+    def __enter__(self):
+        self._old_handler = signal.signal(
+            signal.SIGALRM, self._handle_alarm
+        )
+        signal.alarm(self.seconds)
+        return self
+
+    def _handle_alarm(self, signum, frame):
+        signal.alarm(0)
+        sys.exit(2)
+
+    def __exit__(self, *exc):
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, self._old_handler)
+        return False
 
 
 def retry_with_backoff(
@@ -19,6 +58,7 @@ def retry_with_backoff(
     exceptions: tuple[type[Exception], ...] = (Exception,),
     on_retry: Callable[[int, float, Exception], None] | None = None,
     jitter: bool = False,
+    connectivity_check: Callable[[], None] | None = None,
 ):
     """Decorator for retry with exponential backoff.
 
@@ -34,6 +74,8 @@ def retry_with_backoff(
         on_retry: Optional callback called before each retry with
             (attempt_number, delay, exception)
         jitter: Add random jitter to delays to prevent thundering herd
+        connectivity_check: Optional callable run once before first attempt.
+            If it raises, the exception propagates with zero retries.
 
     Returns:
         Decorated function with retry behavior
@@ -55,6 +97,9 @@ def retry_with_backoff(
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
+            if connectivity_check is not None:
+                connectivity_check()
+
             last_exception = None
 
             for attempt in range(max_retries + 1):

--- a/src/imeteo_radar/sources/dwd.py
+++ b/src/imeteo_radar/sources/dwd.py
@@ -6,10 +6,7 @@ Handles downloading and processing of DWD radar composite data.
 """
 
 import os
-import socket
-import ssl
 import tempfile
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -110,29 +107,6 @@ class DWDRadarSource(RadarSource):
 
         directory_url = f"{self.base_url}/{product}/"
         logger.debug(f"Fetching DWD directory: {directory_url}")
-
-        # Diagnostic: log DNS + TCP + TLS timing to debug persistent failures
-        host = "opendata.dwd.de"
-        try:
-            dns_start = time.monotonic()
-            addrs = socket.getaddrinfo(host, 443, socket.AF_UNSPEC, socket.SOCK_STREAM)
-            dns_ms = (time.monotonic() - dns_start) * 1000
-            ips = [addr[4][0] for addr in addrs]
-            logger.info(f"DWD DNS: {host} -> {ips} ({dns_ms:.0f}ms)")
-
-            tcp_start = time.monotonic()
-            sock = socket.create_connection((ips[0], 443), timeout=10)
-            tcp_ms = (time.monotonic() - tcp_start) * 1000
-            logger.info(f"DWD TCP: {ips[0]}:443 connected ({tcp_ms:.0f}ms)")
-
-            tls_start = time.monotonic()
-            ctx = ssl.create_default_context()
-            ssock = ctx.wrap_socket(sock, server_hostname=host)
-            tls_ms = (time.monotonic() - tls_start) * 1000
-            logger.info(f"DWD TLS: {ssock.version()} handshake ({tls_ms:.0f}ms)")
-            ssock.close()
-        except Exception as diag_err:
-            logger.warning(f"DWD connectivity diagnostic failed: {diag_err}")
 
         response = requests.get(directory_url, timeout=15)
         response.raise_for_status()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -254,3 +254,226 @@ class TestRetryIntegration:
         assert calls[0] == pytest.approx(1.0, rel=0.1)
         assert calls[1] == pytest.approx(2.0, rel=0.1)
         assert calls[2] == pytest.approx(4.0, rel=0.1)
+
+
+class TestConnectivityCheck:
+    """Tests for connectivity_check parameter in retry_with_backoff"""
+
+    def test_connectivity_check_runs_before_first_attempt(self):
+        """Test that connectivity_check is called before the retry loop"""
+        from imeteo_radar.core.retry import retry_with_backoff
+
+        call_order = []
+
+        def check():
+            call_order.append("check")
+
+        @retry_with_backoff(max_retries=3, connectivity_check=check)
+        def func():
+            call_order.append("func")
+            return "ok"
+
+        result = func()
+        assert result == "ok"
+        assert call_order == ["check", "func"]
+
+    def test_connectivity_check_failure_bypasses_retries(self):
+        """Test that ConnectionError from check propagates without retries"""
+        from imeteo_radar.core.retry import retry_with_backoff
+
+        func_called = False
+
+        def failing_check():
+            raise ConnectionError("host unreachable")
+
+        @retry_with_backoff(
+            max_retries=3,
+            base_delay=0.01,
+            exceptions=(ValueError,),
+            connectivity_check=failing_check,
+        )
+        def func():
+            nonlocal func_called
+            func_called = True
+            return "ok"
+
+        with pytest.raises(ConnectionError, match="host unreachable"):
+            func()
+
+        assert not func_called
+
+    def test_no_connectivity_check_default(self):
+        """Test that default None connectivity_check does nothing"""
+        from imeteo_radar.core.retry import retry_with_backoff
+
+        @retry_with_backoff(max_retries=1, base_delay=0.01)
+        def func():
+            return "ok"
+
+        assert func() == "ok"
+
+    def test_connectivity_check_passes_then_func_retries_normally(self):
+        """Test that if check passes, normal retry behavior continues"""
+        from imeteo_radar.core.retry import retry_with_backoff
+
+        call_count = 0
+
+        def passing_check():
+            pass
+
+        @retry_with_backoff(
+            max_retries=2,
+            base_delay=0.01,
+            exceptions=(ValueError,),
+            connectivity_check=passing_check,
+        )
+        def func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("transient")
+            return "ok"
+
+        assert func() == "ok"
+        assert call_count == 2
+
+
+class TestTcpProbe:
+    """Tests for tcp_probe utility function"""
+
+    @patch("socket.create_connection")
+    def test_successful_probe(self, mock_conn):
+        """Test tcp_probe succeeds when connection works"""
+        from imeteo_radar.core.retry import tcp_probe
+
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = mock_sock
+
+        tcp_probe("example.com", 443, 5.0)
+
+        mock_conn.assert_called_once_with(("example.com", 443), timeout=5.0)
+
+    @patch("socket.create_connection", side_effect=OSError("Connection refused"))
+    def test_failed_probe_raises_connection_error(self, mock_conn):
+        """Test tcp_probe raises ConnectionError on failure"""
+        from imeteo_radar.core.retry import tcp_probe
+
+        with pytest.raises(ConnectionError, match="example.com:443 unreachable"):
+            tcp_probe("example.com", 443, 5.0)
+
+    @patch("socket.create_connection", side_effect=OSError("timed out"))
+    def test_timeout_raises_connection_error(self, mock_conn):
+        """Test tcp_probe raises ConnectionError on timeout"""
+        from imeteo_radar.core.retry import tcp_probe
+
+        with pytest.raises(ConnectionError, match="unreachable.*5.0s"):
+            tcp_probe("example.com", 443, 5.0)
+
+
+class TestCheckConnectivityLogic:
+    """Tests for the check_connectivity logic used by RadarSource.
+
+    We test the logic (urlparse + tcp_probe) directly because importing
+    RadarSource triggers the full package import chain which requires
+    Python 3.11+ (datetime.UTC). The actual method in base.py uses
+    the same tcp_probe + urlparse pattern tested here.
+    """
+
+    @patch("socket.create_connection")
+    def test_probes_host_from_url(self, mock_conn):
+        """Test that tcp_probe is called with parsed hostname"""
+        from urllib.parse import urlparse
+        from imeteo_radar.core.retry import tcp_probe
+
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = mock_sock
+
+        # Replicate check_connectivity logic
+        url = "https://example.com/data"
+        host = urlparse(url).hostname
+        tcp_probe(host, 443, 3.0)
+
+        mock_conn.assert_called_once_with(("example.com", 443), timeout=3.0)
+
+    @patch("socket.create_connection", side_effect=OSError("Connection refused"))
+    def test_raises_connection_error_on_unreachable(self, mock_conn):
+        """Test that ConnectionError propagates when host is unreachable"""
+        from urllib.parse import urlparse
+        from imeteo_radar.core.retry import tcp_probe
+
+        url = "https://example.com/data"
+        host = urlparse(url).hostname
+        with pytest.raises(ConnectionError):
+            tcp_probe(host, 443, 5.0)
+
+    @patch("socket.create_connection")
+    def test_skips_when_no_url(self, mock_conn):
+        """Test that no probe happens when url is None"""
+        from urllib.parse import urlparse
+        from imeteo_radar.core.retry import tcp_probe
+
+        # Replicate check_connectivity: skip when no base_url
+        url = None
+        if url is not None:
+            host = urlparse(url).hostname
+            if host:
+                tcp_probe(host, 443, 5.0)
+
+        mock_conn.assert_not_called()
+
+    @patch("socket.create_connection")
+    def test_parses_dwd_host_correctly(self, mock_conn):
+        """Test correct host extraction from DWD URL"""
+        from urllib.parse import urlparse
+        from imeteo_radar.core.retry import tcp_probe
+
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_conn.return_value = mock_sock
+
+        url = "https://opendata.dwd.de/weather/radar/composite"
+        host = urlparse(url).hostname
+        tcp_probe(host, 443, 5.0)
+
+        mock_conn.assert_called_once_with(("opendata.dwd.de", 443), timeout=5.0)
+
+
+class TestExecutionTimeout:
+    """Tests for ExecutionTimeout context manager"""
+
+    def test_no_timeout_when_fast(self):
+        """Test that fast operations complete normally"""
+        from imeteo_radar.core.retry import ExecutionTimeout
+
+        with ExecutionTimeout(10):
+            result = 1 + 1
+
+        assert result == 2
+
+    def test_timeout_raises_system_exit(self):
+        """Test that timeout triggers SystemExit(2)"""
+        from imeteo_radar.core.retry import ExecutionTimeout
+
+        with pytest.raises(SystemExit) as exc_info:
+            with ExecutionTimeout(1, message="test timeout"):
+                time.sleep(3)
+
+        assert exc_info.value.code == 2
+
+    def test_alarm_cleared_on_normal_exit(self):
+        """Test that SIGALRM is cleared after normal context exit"""
+        import signal
+
+        from imeteo_radar.core.retry import ExecutionTimeout
+
+        with ExecutionTimeout(60):
+            pass
+
+        # Alarm should be cleared (0 means no alarm pending)
+        remaining = signal.alarm(0)
+        assert remaining == 0


### PR DESCRIPTION
## Summary
- Add `tcp_probe()` for fast TCP reachability check before retry loops — fail fast instead of burning all retries on unreachable hosts
- Add `check_connectivity()` to `RadarSource` base class, called before fetch/composite downloads
- Add `ExecutionTimeout` context manager (SIGALRM wall-clock deadline) with `--timeout` CLI flag (default 180s, exit code 2)
- Remove inline DWD DNS/TCP/TLS diagnostic code — replaced by the generic base class implementation
- Add `connectivity_check` parameter to `retry_with_backoff` decorator for pre-retry validation

## Test plan
- [ ] `pytest tests/test_retry.py` — all new tests pass (tcp_probe, ExecutionTimeout, connectivity_check)
- [ ] `imeteo-radar fetch --source dwd --timeout 5` — verify timeout triggers exit code 2
- [ ] `imeteo-radar composite --timeout 180` — verify normal completion within timeout
- [ ] Disconnect network → `imeteo-radar fetch --source dwd` — verify fast ConnectionError instead of slow retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)