### PR TITLE
fix: Timeout exits cleanly (exit 0) for CronJob compatibility

### DIFF
--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -88,7 +88,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--timeout",
         type=int,
         default=180,
-        help="Max execution time in seconds (default: 180). Exit code 2 on timeout.",
+        help="Max execution time in seconds (default: 180). Exits cleanly on timeout.",
     )
 
     # Reprocess count for non-backload mode
@@ -263,7 +263,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--timeout",
         type=int,
         default=180,
-        help="Max execution time in seconds (default: 180). Exit code 2 on timeout.",
+        help="Max execution time in seconds (default: 180). Exits cleanly on timeout.",
     )
     composite_parser.add_argument(
         "--disable-upload",
@@ -1086,7 +1086,7 @@ def main():
         log_file=log_file,
     )
 
-    from .core.retry import ExecutionTimeout
+    from .core.retry import ExecutionTimeout, ExecutionTimeoutError
 
     timeout = getattr(args, "timeout", 0)
 
@@ -1111,11 +1111,9 @@ def main():
     except KeyboardInterrupt:
         logger.warning("Operation cancelled by user")
         return 1
-    except SystemExit as e:
-        if e.code == 2 and timeout > 0:
-            logger.error(f"Execution timeout after {timeout}s")
-            return 2
-        raise
+    except ExecutionTimeoutError:
+        logger.warning(f"Execution timeout after {timeout}s, next run will continue")
+        return 0
     except Exception as e:
         logger.error(f"Error: {e}")
         return 1

--- a/src/imeteo_radar/core/retry.py
+++ b/src/imeteo_radar/core/retry.py
@@ -26,8 +26,15 @@ def tcp_probe(host: str, port: int = 443, timeout: float = 5.0) -> None:
         ) from e
 
 
+class ExecutionTimeoutError(Exception):
+    """Raised when ExecutionTimeout deadline is exceeded."""
+
+
 class ExecutionTimeout:
-    """SIGALRM-based wall-clock deadline. Unix-only. Raises SystemExit(2) on timeout."""
+    """SIGALRM-based wall-clock deadline. Unix-only.
+
+    Raises ExecutionTimeoutError when the deadline is exceeded.
+    """
 
     def __init__(self, seconds: int, message: str = "Execution timeout"):
         self.seconds = seconds
@@ -43,7 +50,7 @@ class ExecutionTimeout:
 
     def _handle_alarm(self, signum, frame):
         signal.alarm(0)
-        sys.exit(2)
+        raise ExecutionTimeoutError(self.message)
 
     def __exit__(self, *exc):
         signal.alarm(0)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -455,15 +455,13 @@ class TestExecutionTimeout:
 
         assert result == 2
 
-    def test_timeout_raises_system_exit(self):
-        """Test that timeout triggers SystemExit(2)"""
-        from imeteo_radar.core.retry import ExecutionTimeout
+    def test_timeout_raises_execution_timeout_error(self):
+        """Test that timeout triggers ExecutionTimeoutError"""
+        from imeteo_radar.core.retry import ExecutionTimeout, ExecutionTimeoutError
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(ExecutionTimeoutError):
             with ExecutionTimeout(1, message="test timeout"):
                 time.sleep(3)
-
-        assert exc_info.value.code == 2
 
     def test_alarm_cleared_on_normal_exit(self):
         """Test that SIGALRM is cleared after normal context exit"""


### PR DESCRIPTION
## Summary
- Replace `sys.exit(2)` with `ExecutionTimeoutError` exception in `ExecutionTimeout`
- CLI catches timeout and returns exit code 0 with a warning log
- Prevents K8s CronJob pods from being marked as `Failed` on timeout
- Next scheduled run picks up where the timed-out run stopped

## Test plan
- [ ] `pytest tests/test_retry.py -k TestExecutionTimeout` — passes
- [ ] Timeout triggers warning log, not error
- [ ] Container exits with code 0 on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)