### PR TITLE
release: v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.1] - 2026-03-04
+
+### Fixed
+- **Timeout exits cleanly (exit 0)** for Kubernetes CronJob compatibility — previously
+  `sys.exit(2)` caused pods to be marked as Failed; now raises `ExecutionTimeoutError`
+  caught by CLI, logs a warning, and exits 0 so the next scheduled run continues normally
+
 ## [2.9.0] - 2026-03-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.9.0"
+version = "2.9.1"
 description = "Weather radar data processor for DWD, SHMU, CHMI, OMSZ, ARSO, and IMGW weather radar data"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version to 2.9.1
- Hotfix: timeout exits cleanly (exit 0) for K8s CronJob compatibility

## Post-merge
```bash
git checkout main && git pull
git tag v2.9.1 && git push origin v2.9.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)