### PR TITLE
release: v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.2] - 2026-03-06
+
+### Changed
+- **Deduplicated CLI code** — extracted shared uploader init, cache args, and export
+  format args into `utils/cli_helpers.py`, reducing maintenance surface across
+  `cli.py` (-141 lines) and `cli_composite.py` (-239 lines)
+- **Use centralized source registry** in composite command — replaced manual if/elif
+  chain with `get_source_instance()`/`get_source_config()` from `config/sources.py`
+- **Cached `get_available_timestamps()` per source** in composite — eliminated 3
+  redundant calls per source during download phase
+
+### Fixed
+- **`source.get_extent()` hoisted above backload loop** — was called on every file
+  iteration instead of once before the loop
+
+### Removed
+- Dead code: `_find_common_timestamp_with_tolerance` (never called, superseded by
+  `_find_multiple_common_timestamps`)
+- Redundant `_export_individual_sources` wrapper (superseded by `_export_single_source`)
+
 ## [2.9.1] - 2026-03-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imeteo-radar"
-version = "2.9.1"
+version = "2.9.2"
 description = "Weather radar data processor for DWD, SHMU, CHMI, OMSZ, ARSO, and IMGW weather radar data"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version to `2.9.2` in `pyproject.toml`
- Add `[2.9.2]` changelog entry covering CLI deduplication (from #31)

## Changes in v2.9.2
- Deduplicated CLI code across `cli.py` and `cli_composite.py` (-380 lines net)
- Used centralized source registry in composite command
- Cached `get_available_timestamps()` per source
- Hoisted `source.get_extent()` above backload loop
- Removed dead code (`_find_common_timestamp_with_tolerance`, `_export_individual_sources`)

## Test plan
- [ ] CI passes
- [ ] After merge: `git tag v2.9.2 && git push origin v2.9.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)