### PR TITLE
chore: Tech debt cleanup and ruff lint fixes

### DIFF
--- a/src/imeteo_radar/__init__.py
+++ b/src/imeteo_radar/__init__.py
@@ -1,23 +1,19 @@
 """
-Radar SHMU - Multi-source radar data processor
+iMeteo Radar - Multi-source radar data processor
 
-A modern, high-performance radar data processing system for DWD, SHMU, CHMI, ARSO, and OMSZ weather radar data.
+A modern, high-performance radar data processing system for DWD, SHMU, CHMI, ARSO, OMSZ, and IMGW weather radar data.
 Supports parallel downloads, fast interpolation, and optimized PNG exports.
 """
 
-__version__ = "1.4.0"
+__version__ = "2.9.2"
 __author__ = "Radar Processing Team"
 
-from .processing.animator import RadarAnimator
-from .processing.exporter import ExportConfig, MultiFormatExporter, PNGExporter
-from .processing.merger import RadarMerger
+from .processing.exporter import ExportConfig, MultiFormatExporter
 from .sources.arso import ARSORadarSource
 from .sources.chmi import CHMIRadarSource
 from .sources.dwd import DWDRadarSource
 from .sources.imgw import IMGWRadarSource
 from .sources.omsz import OMSZRadarSource
-
-# Main exports
 from .sources.shmu import SHMURadarSource
 
 __all__ = [
@@ -27,9 +23,6 @@ __all__ = [
     "ARSORadarSource",
     "OMSZRadarSource",
     "IMGWRadarSource",
-    "RadarMerger",
     "MultiFormatExporter",
-    "PNGExporter",  # Backward compatibility alias
     "ExportConfig",
-    "RadarAnimator",
 ]

--- a/src/imeteo_radar/cli.py
+++ b/src/imeteo_radar/cli.py
@@ -1110,10 +1110,7 @@ def coverage_mask_command(args) -> int:
         logger.error(f"Import error: {e}")
         return 1
     except Exception as e:
-        logger.error(f"Error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.error(f"Error: {e}", exc_info=True)
         return 1
 
 
@@ -1169,10 +1166,7 @@ def cache_command(args) -> int:
             return 1
 
     except Exception as e:
-        logger.error(f"Cache command error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.error(f"Cache command error: {e}", exc_info=True)
         return 1
 
 
@@ -1285,10 +1279,7 @@ def transform_cache_command(args) -> int:
         logger.error(f"Import error: {e}")
         return 1
     except Exception as e:
-        logger.error(f"Transform cache command error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.error(f"Transform cache command error: {e}", exc_info=True)
         return 1
 
 

--- a/src/imeteo_radar/cli_composite.py
+++ b/src/imeteo_radar/cli_composite.py
@@ -235,10 +235,7 @@ def composite_command_impl(args: Any) -> int:
         logger.warning("Interrupted by user")
         return 1
     except Exception as e:
-        logger.error(f"Error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.error(f"Error: {e}", exc_info=True)
         return 1
 
 
@@ -895,10 +892,10 @@ def _process_latest(args, sources, exporter, export_config, output_dir, uploader
             gc.collect()
 
         except Exception as e:
-            logger.error(f"Failed to create composite for {common_timestamp}: {e}")
-            import traceback
-
-            traceback.print_exc()
+            logger.error(
+                f"Failed to create composite for {common_timestamp}: {e}",
+                exc_info=True,
+            )
 
     # Update extent index if processed any composites
     if processed_count > 0:
@@ -1533,10 +1530,7 @@ def _process_backload(args, sources, exporter, export_config, output_dir, upload
             gc.collect()
 
         except Exception as e:
-            logger.error(f"Failed to create composite: {e}")
-            import traceback
-
-            traceback.print_exc()
+            logger.error(f"Failed to create composite: {e}", exc_info=True)
 
     logger.info(
         f"Processed {processed_count} composites", extra={"count": processed_count}

--- a/src/imeteo_radar/config/shmu_colormap.py
+++ b/src/imeteo_radar/config/shmu_colormap.py
@@ -146,9 +146,6 @@ def get_color_for_dbz(dbz_value):
     return cmap(norm_value)
 
 
-# For backward compatibility
-create_discrete_colormap = get_shmu_colormap
-
 if __name__ == "__main__":
     logger.info("SHMU Official Radar Colormap")
 

--- a/src/imeteo_radar/core/alerts.py
+++ b/src/imeteo_radar/core/alerts.py
@@ -7,10 +7,10 @@ the health of radar data sources.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-from collections.abc import Callable
 
 
 class AlertLevel(Enum):

--- a/src/imeteo_radar/core/logging.py
+++ b/src/imeteo_radar/core/logging.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 
 class StructuredFormatter(logging.Formatter):

--- a/src/imeteo_radar/core/projection.py
+++ b/src/imeteo_radar/core/projection.py
@@ -10,7 +10,7 @@ Handles conversion between different coordinate systems including:
 """
 
 import warnings
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 
@@ -31,7 +31,7 @@ class ProjectionHandler:
     def __init__(self):
         self.transformers = {}  # Cache transformers for efficiency
 
-    def create_transformer(self, src_crs: str, dst_crs: str) -> Optional["Transformer"]:
+    def create_transformer(self, src_crs: str, dst_crs: str) -> "Transformer | None":
         """Create and cache a coordinate transformer"""
         if not PYPROJ_AVAILABLE:
             warnings.warn(

--- a/src/imeteo_radar/core/retry.py
+++ b/src/imeteo_radar/core/retry.py
@@ -9,10 +9,9 @@ backoff strategies and callback hooks.
 import random
 import signal
 import socket
-import sys
 import time
-from functools import wraps
 from collections.abc import Callable
+from functools import wraps
 
 
 def tcp_probe(host: str, port: int = 443, timeout: float = 5.0) -> None:

--- a/src/imeteo_radar/processing/animator.py
+++ b/src/imeteo_radar/processing/animator.py
@@ -5,10 +5,12 @@ This module creates GIF animations from radar PNG sequences for SHMU, DWD, and m
 Supports multiple products per source and handles different timestamp formats.
 """
 
-import logging
 import re
+import warnings
 from datetime import datetime
 from pathlib import Path
+
+from ..core.logging import get_logger
 
 try:
     from PIL import Image
@@ -16,16 +18,12 @@ try:
     PIL_AVAILABLE = True
 except ImportError:
     PIL_AVAILABLE = False
-    import sys
-
-    print(
-        "Warning: PIL (Pillow) not available. Install with: pip install Pillow",
-        file=sys.stderr,
+    warnings.warn(
+        "PIL (Pillow) not available. Install with: pip install Pillow",
+        stacklevel=2,
     )
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RadarAnimator:

--- a/src/imeteo_radar/processing/compositor.py
+++ b/src/imeteo_radar/processing/compositor.py
@@ -208,10 +208,7 @@ class RadarCompositor:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to merge {source_name}: {e}")
-            import traceback
-
-            traceback.print_exc()
+            logger.error(f"Failed to merge {source_name}: {e}", exc_info=True)
             return False
 
     def _get_source_crs_and_transform(

--- a/src/imeteo_radar/processing/coverage_mask.py
+++ b/src/imeteo_radar/processing/coverage_mask.py
@@ -31,6 +31,7 @@ from ..config.sources import (
 from ..core.base import lonlat_to_mercator
 from ..core.logging import get_logger
 from ..core.projections import get_crs_web_mercator, get_crs_wgs84
+from ..utils.extent_loader import get_wgs84_from_extent
 
 logger = get_logger(__name__)
 
@@ -58,41 +59,6 @@ def _load_extent_index(output_dir: str) -> dict[str, Any] | None:
     return None
 
 
-def _get_wgs84_from_extent_index(
-    extent_data: dict[str, Any],
-) -> dict[str, float] | None:
-    """
-    Extract WGS84 bounds from extent_index.json data.
-
-    Handles all three known formats:
-    - Composite pipeline: top-level 'wgs84' key
-    - Composite metadata: nested under 'extent.wgs84'
-    - CLI fetch: nested under 'source.extent' (with west/east/south/north)
-
-    Args:
-        extent_data: Parsed extent_index.json data
-
-    Returns:
-        Dictionary with west, east, south, north or None
-    """
-    # Composite pipeline format: top-level "wgs84" key
-    if "wgs84" in extent_data:
-        return extent_data["wgs84"]
-
-    # Composite metadata format: nested under "extent.wgs84"
-    extent = extent_data.get("extent", {})
-    if "wgs84" in extent:
-        return extent["wgs84"]
-
-    # CLI fetch format: nested under "source.extent"
-    source = extent_data.get("source", {})
-    source_extent = source.get("extent", {})
-    if "west" in source_extent:
-        return source_extent
-
-    return None
-
-
 def _load_source_extent(
     source_name: str, output_base_dir: str | None = None
 ) -> dict[str, float] | None:
@@ -113,7 +79,7 @@ def _load_source_extent(
     canonical_dir = os.path.join("/tmp/iradar-data/extent", source_name)
     extent_data = _load_extent_index(canonical_dir)
     if extent_data is not None:
-        result = _get_wgs84_from_extent_index(extent_data)
+        result = get_wgs84_from_extent(extent_data)
         if result is not None:
             return result
 
@@ -124,7 +90,7 @@ def _load_source_extent(
             source_dir = os.path.join(output_base_dir, config["folder"])
             extent_data = _load_extent_index(source_dir)
             if extent_data is not None:
-                return _get_wgs84_from_extent_index(extent_data)
+                return get_wgs84_from_extent(extent_data)
 
     return None
 
@@ -567,7 +533,7 @@ def generate_source_coverage_mask(
         )
         return None
 
-    target_wgs84 = _get_wgs84_from_extent_index(extent_data)
+    target_wgs84 = get_wgs84_from_extent(extent_data)
     if target_wgs84 is None:
         logger.error(
             f"No WGS84 bounds in extent_index.json for {source_name}",
@@ -766,7 +732,7 @@ def generate_composite_coverage_mask(
     metadata = extent_info.get("metadata", {})
     resolution_m = metadata.get("resolution_m", resolution_m)
 
-    mask_extent = _get_wgs84_from_extent_index(extent_info)
+    mask_extent = get_wgs84_from_extent(extent_info)
     if mask_extent is None:
         logger.error("No WGS84 bounds in composite extent_index.json")
         return None

--- a/src/imeteo_radar/processing/coverage_mask.py
+++ b/src/imeteo_radar/processing/coverage_mask.py
@@ -23,6 +23,7 @@ import numpy as np
 from PIL import Image
 from rasterio.transform import from_bounds
 from rasterio.warp import Resampling, reproject
+
 from ..config.sources import (
     get_all_source_names,
     get_source_config,

--- a/src/imeteo_radar/processing/exporter.py
+++ b/src/imeteo_radar/processing/exporter.py
@@ -710,7 +710,3 @@ class MultiFormatExporter:
                 f"Unknown data type (units: {units}, quantity: {quantity}), using SHMU colormap",
             )
             return {"name": "reflectivity_shmu", **self.colormaps["reflectivity_shmu"]}
-
-
-# Backward compatibility alias
-PNGExporter = MultiFormatExporter

--- a/src/imeteo_radar/sources/arso.py
+++ b/src/imeteo_radar/sources/arso.py
@@ -394,7 +394,7 @@ class ARSORadarSource(RadarSource):
             )
         else:
             logger.debug(
-                f"ARSO: Latest timestamp doesn't match any requested timestamps",
+                "ARSO: Latest timestamp doesn't match any requested timestamps",
                 extra={"source": "arso"},
             )
 

--- a/src/imeteo_radar/sources/arso.py
+++ b/src/imeteo_radar/sources/arso.py
@@ -11,7 +11,7 @@ Documentation: https://meteo.arso.gov.si/uploads/meteo/help/sl/SRD3Format.html
 
 import os
 import tempfile
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -452,13 +452,13 @@ class ARSORadarSource(RadarSource):
                         timestamp = f"{time_parts[0]:04d}{time_parts[1]:02d}{time_parts[2]:02d}{time_parts[3]:02d}{time_parts[4]:02d}00"
                     else:
                         # Fallback to current time
-                        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M00")
+                        timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M00")
                     result["timestamp"] = timestamp
                 except Exception as e:
                     logger.warning(
                         f"Could not parse timestamp: {e}", extra={"source": "arso"}
                     )
-                    result["timestamp"] = datetime.utcnow().strftime("%Y%m%d%H%M00")
+                    result["timestamp"] = datetime.now(UTC).strftime("%Y%m%d%H%M00")
 
                 downloaded_files.append(result)
                 if result["cached"]:
@@ -500,7 +500,7 @@ class ARSORadarSource(RadarSource):
             if isinstance(time_parts, list) and len(time_parts) >= 5:
                 timestamp = f"{time_parts[0]:04d}{time_parts[1]:02d}{time_parts[2]:02d}{time_parts[3]:02d}{time_parts[4]:02d}00"
             else:
-                timestamp = datetime.utcnow().strftime("%Y%m%d%H%M00")
+                timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M00")
 
             # Determine product type from filename or header
             domain = header.get("domain", "SI0")

--- a/src/imeteo_radar/sources/shmu.py
+++ b/src/imeteo_radar/sources/shmu.py
@@ -13,9 +13,6 @@ from typing import Any
 import requests
 import urllib3
 
-# Suppress SSL verification warnings for SHMU (their certificate has issues)
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 from ..core.base import (
     RadarSource,
     extract_hdf5_corner_extent,
@@ -37,6 +34,9 @@ from ..utils.timestamps import (
     filter_timestamps_by_range,
     generate_timestamp_candidates,
 )
+
+# Suppress SSL verification warnings for SHMU (their certificate has issues)
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logger = get_logger(__name__)
 

--- a/src/imeteo_radar/utils/parallel_download.py
+++ b/src/imeteo_radar/utils/parallel_download.py
@@ -7,10 +7,10 @@ across all source classes (DWD, SHMU, CHMI, OMSZ, IMGW).
 """
 
 import os
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
-from collections.abc import Callable
 
 from ..core.logging import get_logger
 

--- a/src/imeteo_radar/utils/processed_cache.py
+++ b/src/imeteo_radar/utils/processed_cache.py
@@ -20,7 +20,7 @@ Storage Format:
 
 import json
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -299,7 +299,7 @@ class ProcessedDataCache:
             "dimensions": list(data.shape),
             "source_metadata": radar_data.get("metadata", {}),
             "cached_at": time.time(),
-            "cached_at_iso": datetime.utcnow().isoformat() + "Z",
+            "cached_at_iso": datetime.now(UTC).isoformat(),
         }
 
         with open(metadata_path, "w") as f:

--- a/src/imeteo_radar/utils/spaces_uploader.py
+++ b/src/imeteo_radar/utils/spaces_uploader.py
@@ -108,9 +108,9 @@ class SpacesUploader:
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
             if error_code == "404":
-                raise ValueError(f"Bucket not found") from e
+                raise ValueError("Bucket not found") from e
             elif error_code == "403":
-                raise ValueError(f"Access denied to bucket") from e
+                raise ValueError("Access denied to bucket") from e
             else:
                 raise ValueError(
                     f"Failed to connect to DigitalOcean Spaces: {e}"


### PR DESCRIPTION
## Summary

- Fix `__version__` mismatch (`1.4.0` → `2.9.2`) in `__init__.py`
- Remove dead backward-compat aliases (`PNGExporter`, `create_discrete_colormap`, `RadarMerger`, `RadarAnimator` exports)
- Replace deprecated `datetime.utcnow()` with `datetime.now(UTC)` in `arso.py`, `processed_cache.py`
- Replace `traceback.print_exc()` with `logger.error(..., exc_info=True)` in `cli.py`, `cli_composite.py`, `compositor.py`
- Standardize `animator.py` logging to use centralized `get_logger()`
- Modernize `Optional[X]` → `X | None` in `projection.py`
- Deduplicate `_get_wgs84_from_extent_index` in `coverage_mask.py` (use shared `get_wgs84_from_extent`)
- Fix all ruff lint issues: import sorting (I001), unused imports (F401), extraneous f-prefixes (F541), import ordering (E402)

**17 files changed, -113 / +45 lines (net -68 lines removed)**

## Test plan

- [ ] Verify `ruff check src/imeteo_radar/` passes clean
- [ ] Verify `python -c "import ast; ..."` syntax check passes on all modified files
- [ ] Run `imeteo-radar fetch --source dwd` to confirm no runtime regressions
- [ ] Run `imeteo-radar composite` to confirm compositor still works
- [ ] Verify no public API breakage (only removed unused aliases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)