### PR TITLE
docs: Update documentation for v2.9.2 and v2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to iMeteo Radar project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.9.2] - 2026-03-06
+## [2.9.2] - 2026-03-06 ([#31](https://github.com/franko14/radar-shmu/pull/31), [#32](https://github.com/franko14/radar-shmu/pull/32))
 
 ### Changed
 - **Deduplicated CLI code** — extracted shared uploader init, cache args, and export

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -377,7 +377,7 @@ Precomputed pixel-to-pixel index mappings stored in a three-tier cache for fast 
 
 - Uses int16 indices (~4 bytes/pixel) for memory efficiency
 - `fast_reproject()` applies precomputed grid via numpy array indexing
-- S3 upload happens **only on initial grid compute** — no redundant S3 HEAD checks on cache hits (optimized in v2.9.3)
+- S3 upload happens only on initial grid compute (no per-request S3 checks)
 
 **Implementation**: `src/imeteo_radar/processing/transform_cache.py`
 
@@ -422,7 +422,7 @@ rgba = lut[indices]  # Direct lookup
 
 **Problem**: Creating 4800×4400 coordinate meshgrids (322 MB) that are never used after extent calculation.
 
-**Solution**: Calculate extent from 4 corner coordinates only. Unused `np.linspace()` coordinate arrays were also removed from SHMU, CHMI, IMGW, and OMSZ sources (v2.9.3).
+**Solution**: Calculate extent from 4 corner coordinates only.
 
 ```python
 # Before: 322 MB

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -377,6 +377,7 @@ Precomputed pixel-to-pixel index mappings stored in a three-tier cache for fast 
 
 - Uses int16 indices (~4 bytes/pixel) for memory efficiency
 - `fast_reproject()` applies precomputed grid via numpy array indexing
+- S3 upload happens **only on initial grid compute** — no redundant S3 HEAD checks on cache hits (optimized in v2.9.3)
 
 **Implementation**: `src/imeteo_radar/processing/transform_cache.py`
 
@@ -421,7 +422,7 @@ rgba = lut[indices]  # Direct lookup
 
 **Problem**: Creating 4800×4400 coordinate meshgrids (322 MB) that are never used after extent calculation.
 
-**Solution**: Calculate extent from 4 corner coordinates only.
+**Solution**: Calculate extent from 4 corner coordinates only. Unused `np.linspace()` coordinate arrays were also removed from SHMU, CHMI, IMGW, and OMSZ sources (v2.9.3).
 
 ```python
 # Before: 322 MB
@@ -502,7 +503,7 @@ SHMU and CHMI data is already in Web Mercator (EPSG:3857).
 
 Coordinate extraction:
 1. Read corner coordinates from HDF5 `where` attributes
-2. Create 1D linspace arrays for x and y
+2. Build affine transform from corner coordinates and grid dimensions
 3. No reprojection needed for single-source export
 
 ---
@@ -526,7 +527,7 @@ graph LR
         end
 
         subgraph processing/
-            EXP[exporter.py<br/>PNG export + reproject]
+            EXP[exporter.py<br/>Multi-format export + reproject]
             COMP[compositor.py<br/>Multi-source merge]
             REPR[reprojector.py<br/>Unified reprojection]
             TCACHE[transform_cache.py<br/>Three-tier cache]
@@ -587,7 +588,8 @@ graph LR
 
 ### Export
 
-- **Method**: PIL with pre-computed LUT
+- **Method**: PIL with pre-computed uint8 LUT colormap
+- **API**: `export_variants()` with `ExportConfig` dataclass (formats, resolutions, colormap, reproject flag)
 - **Compression**: Maximum PNG level 9
 - **Speed**: 4-10x faster than matplotlib
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -15,7 +15,7 @@ sequenceDiagram
     participant Cache as ProcessedDataCache<br/>(local + S3)
     participant Source as RadarSource<br/>(e.g. DWD)
     participant Provider as Data Provider<br/>(e.g. opendata.dwd.de)
-    participant Exporter as PNGExporter
+    participant Exporter as MultiFormatExporter
     participant TCache as TransformCache<br/>(memory/disk/S3)
     participant Upload as SpacesUploader<br/>(S3)
 
@@ -59,7 +59,8 @@ sequenceDiagram
         CLI->>Cache: put("dwd", ts, "dmax", radar_data)
         Note over Cache: Save .npz + .json locally<br/>Upload both to S3
 
-        CLI->>Exporter: export_png_fast(radar_data, reproject=True)
+        CLI->>Exporter: export_variants(radar_data, base_path, extent, config)
+        Note over Exporter: config = ExportConfig(reproject=True, colormap_type=...)
         Note over Exporter,TCache: Reprojection (see diagram 4)
         Exporter->>TCache: get_or_compute("dwd", shape, projection)
         TCache-->>Exporter: TransformGrid (row/col indices)
@@ -77,7 +78,7 @@ sequenceDiagram
         CLI->>CLI: output_exists? → skip if yes
         CLI->>Cache: get("dwd", ts, "dmax")
         Cache-->>CLI: radar_data (from .npz + .json)
-        CLI->>Exporter: export_png_fast(radar_data, reproject=True)
+        CLI->>Exporter: export_variants(radar_data, reproject=True)
         Exporter-->>CLI: output_path
         CLI->>Upload: upload_file(...)
     end
@@ -100,7 +101,7 @@ sequenceDiagram
     participant Sources as 6 RadarSources
     participant Providers as Data Providers
     participant Compositor as RadarCompositor
-    participant Exporter as PNGExporter
+    participant Exporter as MultiFormatExporter
     participant Upload as SpacesUploader
 
     User->>CLI: imeteo-radar composite
@@ -175,7 +176,8 @@ sequenceDiagram
             end
 
             opt Export individual source PNG
-                CLI->>Exporter: export_png_fast(radar_data, reproject=True)
+                CLI->>Exporter: export_variants(radar_data, base_path, extent, config)
+                Note over Exporter: config has reproject=True for individual sources
                 CLI->>Upload: upload_file(source_png)
             end
 
@@ -185,8 +187,8 @@ sequenceDiagram
 
         CLI->>Compositor: get_composite()
         Compositor-->>CLI: merged_data (max reflectivity)
-        CLI->>Exporter: export_png_fast(composite, reproject=False)
-        Note over Exporter: Already in Web Mercator, no reprojection needed
+        CLI->>Exporter: export_variants(composite, base_path, extent, config)
+        Note over Exporter: config has reproject=False (already Web Mercator)
         CLI->>Upload: upload_file(composite_png)
     end
 
@@ -280,7 +282,7 @@ Precomputed pixel-to-pixel index mappings for 10-50x faster reprojection. Since 
 
 ```mermaid
 sequenceDiagram
-    participant Exporter as PNGExporter
+    participant Exporter as MultiFormatExporter
     participant TCache as TransformCache
     participant Mem as Tier 1: Memory<br/>(in-process dict)
     participant Disk as Tier 2: Local Disk<br/>/tmp/iradar-data/grid/
@@ -311,7 +313,7 @@ sequenceDiagram
                 TCache->>TCache: Build int16 row/col index arrays
                 TCache->>Mem: Store in memory
                 TCache->>Disk: Save .npz locally
-                TCache->>S3: Upload .npz
+                TCache->>S3: Upload .npz (only on initial compute)
                 TCache-->>Exporter: grid
             end
         end
@@ -348,7 +350,7 @@ How source data in native projections gets reprojected to Web Mercator (EPSG:385
 
 ```mermaid
 sequenceDiagram
-    participant Exporter as PNGExporter<br/>export_png_fast()
+    participant Exporter as MultiFormatExporter<br/>export_variants()
     participant Reproj as reprojector.py
     participant TCache as TransformCache
     participant Rasterio as rasterio.warp
@@ -417,14 +419,15 @@ From raw float32 reflectivity array to optimized PNG file.
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Exporter as PNGExporter
+    participant Exporter as MultiFormatExporter
     participant TCache as TransformCache
     participant PIL as Pillow
 
-    Caller->>Exporter: export_png_fast(radar_data, reproject=True)
+    Caller->>Exporter: export_variants(radar_data, base_path, extent, config)
+    Note over Exporter: config = ExportConfig(reproject=True, colormap_type="shmu", ...)
 
     Note over Exporter: Step 1: Reproject (optional)
-    opt reproject=True and projection_info present
+    opt config.reproject=True and projection_info present
         Exporter->>TCache: get_or_compute(source, ...)
         TCache-->>Exporter: TransformGrid
         Exporter->>Exporter: fast_reproject(data, grid)

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@ Set up your development environment and contribute to iMeteo Radar.
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.11+ (uses `datetime.UTC` and modern type annotations)
 - Git
 - Docker (optional, for testing)
 
@@ -37,8 +37,8 @@ pip install -e ".[dev]"
 ```
 
 This installs:
-- Core dependencies (numpy, h5py, rasterio, matplotlib, requests, PIL, opencv-python, pyproj, netCDF4)
-- Development tools (pytest, black, isort, mypy, flake8)
+- Core dependencies (numpy, h5py, rasterio, requests, PIL, pyproj, netCDF4, python-dotenv)
+- Development tools (pytest, ruff, mypy)
 
 ### 4. Verify Installation
 
@@ -67,7 +67,7 @@ graph TB
             end
 
             subgraph processing["processing/"]
-                EXP["exporter.py - PNG export + reproject"]
+                EXP["exporter.py - Multi-format export + reproject"]
                 COMP["compositor.py - Multi-source merge"]
                 REPR["reprojector.py - Unified reprojection"]
                 TCACHE["transform_cache.py - Three-tier cache"]
@@ -132,26 +132,20 @@ pytest -v -s  # Show print statements
 
 ## Code Quality
 
-### Formatting (Black)
+### Linting & Formatting (ruff)
 
 ```bash
-# Check formatting
-black --check src/
+# Check for lint issues
+ruff check src/
 
-# Apply formatting
-black src/
-```
+# Auto-fix lint issues
+ruff check --fix src/
 
-Configuration: 88 character line length (default)
+# Format code
+ruff format src/
 
-### Import Sorting (isort)
-
-```bash
-# Check imports
-isort --check-only src/
-
-# Sort imports
-isort src/
+# Check formatting without applying
+ruff format --check src/
 ```
 
 ### Type Checking (mypy)
@@ -160,16 +154,10 @@ isort src/
 mypy src/
 ```
 
-### Linting (flake8)
-
-```bash
-flake8 src/
-```
-
 ### Run All Checks
 
 ```bash
-black src/ && isort src/ && mypy src/ && flake8 src/
+ruff check src/ && ruff format --check src/ && mypy src/
 ```
 
 ---
@@ -230,19 +218,23 @@ class NewSourceRadarSource(RadarSource):
         pass
 ```
 
-### 2. Add to CLI
+### 2. Register in Source Registry
 
-Update `src/imeteo_radar/cli.py`:
+Update `src/imeteo_radar/config/sources.py`:
 
 ```python
-# Add to source choices
-parser.add_argument('--source', choices=['dwd', 'shmu', 'chmi', 'newsource'])
-
-# Add to fetch_command
-if args.source == 'newsource':
-    from .sources.newsource import NewSourceRadarSource
-    source = NewSourceRadarSource()
+# Add to SOURCE_REGISTRY
+"newsource": SourceConfig(
+    name="newsource",
+    country="newcountry",
+    folder="newcountry",
+    source_class="NewSourceRadarSource",
+    source_module="imeteo_radar.sources.newsource",
+    product="maxz",
+),
 ```
+
+The CLI automatically picks up sources from the registry — no manual if/elif chains needed.
 
 ### 3. Add Tests
 

--- a/docs/memory-profiling-results.md
+++ b/docs/memory-profiling-results.md
@@ -113,6 +113,15 @@ The main memory hog is holding all 5 source radar arrays in `sources_data` simul
 
 Plus coordinate arrays, interpolation temporaries, and composite grid (~88 MB).
 
+## v2.9.3 Optimizations (March 2026)
+
+Additional memory and performance improvements applied in v2.9.3:
+
+- **Guaranteed array cleanup** — compositor wraps reprojected arrays in `try/finally` for deterministic memory release, preventing leaks on exceptions
+- **Avoided redundant `float32` copies** — compositor and reprojector skip `astype(np.float32)` when data is already float32, saving allocation overhead
+- **Removed unused coordinate arrays** — SHMU, CHMI, IMGW, and OMSZ sources no longer create `np.linspace()` arrays that were computed but never used after extent calculation
+- **Removed redundant S3 calls** — `_ensure_in_s3()` HEAD check removed from transform cache hot path; `sync_with_s3()` paginator removed from default composite flow
+
 ## Future Optimization Opportunities
 
 1. **Stream processing**: Process and merge each source individually, deleting radar_data immediately after merge (requires skipping individual exports or changing export order).

--- a/docs/memory-profiling-results.md
+++ b/docs/memory-profiling-results.md
@@ -113,14 +113,12 @@ The main memory hog is holding all 5 source radar arrays in `sources_data` simul
 
 Plus coordinate arrays, interpolation temporaries, and composite grid (~88 MB).
 
-## v2.9.3 Optimizations (March 2026)
-
-Additional memory and performance improvements applied in v2.9.3:
+## Current Safeguards
 
 - **Guaranteed array cleanup** — compositor wraps reprojected arrays in `try/finally` for deterministic memory release, preventing leaks on exceptions
-- **Avoided redundant `float32` copies** — compositor and reprojector skip `astype(np.float32)` when data is already float32, saving allocation overhead
-- **Removed unused coordinate arrays** — SHMU, CHMI, IMGW, and OMSZ sources no longer create `np.linspace()` arrays that were computed but never used after extent calculation
-- **Removed redundant S3 calls** — `_ensure_in_s3()` HEAD check removed from transform cache hot path; `sync_with_s3()` paginator removed from default composite flow
+- **No redundant allocations** — compositor and reprojector skip `astype(np.float32)` when data is already float32
+- **No unused arrays** — sources compute extent from corner coordinates only, without intermediate coordinate arrays
+- **Minimal S3 overhead** — transform cache uploads to S3 only on initial compute, with no per-request HEAD checks
 
 ## Future Optimization Opportunities
 


### PR DESCRIPTION
## Summary
- Update docs to reflect recent code changes from v2.9.2 (#31, #32) and v2.9.3 (#34)
- Replace outdated API references (`export_png_fast` → `export_variants`, `PNGExporter` → `MultiFormatExporter`)
- Modernize tooling references (flake8/black/isort → ruff, Python 3.9+ → 3.11+)

### Files changed
- **architecture.md** — transform cache S3 behavior, export API, coordinate generation
- **data-flow.md** — all sequence diagrams updated for `export_variants()` + `ExportConfig`
- **development.md** — Python 3.11+, ruff tooling, registry-based source registration
- **memory-profiling-results.md** — added v2.9.3 optimization notes
- **CHANGELOG.md** — added PR hyperlinks to v2.9.2 entry

## Test plan
- [ ] Verify mermaid diagrams render correctly on GitHub
- [ ] Confirm docs reflect actual code behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)