### PR TITLE
fix: add DBZ render threshold to suppress sub-threshold pixels

### DIFF
--- a/src/imeteo_radar/processing/exporter.py
+++ b/src/imeteo_radar/processing/exporter.py
@@ -19,6 +19,9 @@ from ..core.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Minimum DBZ value to render — pixels below this threshold are transparent
+MIN_RENDER_DBZ = -30
+
 
 @dataclass
 class ExportConfig:
@@ -240,7 +243,7 @@ class MultiFormatExporter:
 
         # Map data values to LUT indices (0-255)
         # Handle NaN/invalid values separately
-        valid_mask = np.isfinite(data)
+        valid_mask = np.isfinite(data) & (data >= MIN_RENDER_DBZ)
 
         # Clip and scale valid data to 0-255 index range
         indices = np.zeros(data.shape, dtype=np.uint8)

--- a/src/imeteo_radar/processing/exporter.py
+++ b/src/imeteo_radar/processing/exporter.py
@@ -20,7 +20,7 @@ from ..core.logging import get_logger
 logger = get_logger(__name__)
 
 # Minimum DBZ value to render — pixels below this threshold are transparent
-MIN_RENDER_DBZ = -30
+MIN_RENDER_DBZ = 10
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Adds `MIN_RENDER_DBZ = -30` constant in `exporter.py`
- Pixels with DBZ below -30 are now fully transparent instead of rendered

## Test plan

- [ ] Run `pytest tests/ --override-ini="addopts="` — existing 47 tests pass
- [ ] Fetch a source (`imeteo-radar fetch --source shmu --output ./outputs/slovakia`) and verify sub-threshold areas are transparent in the output PNG